### PR TITLE
First round of closed testing feedback

### DIFF
--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
@@ -6,4 +6,5 @@ object FeatureFlags {
     const val ROUTE_DETAIL_PREVENT_ZOOM_WHEN_HAVE_SOURCE_STOP = true
     const val ROUTE_DETAIL_NEAREST_STOP = true
     const val STOP_DETAIL_SHOW_IN_MAPS_BUTTON = true
+    const val MAP_SEARCH_SCREEN_NEARBY_STOPS_SEARCH = true
 }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
@@ -1,6 +1,7 @@
 package cl.emilym.sinatra
 
 object FeatureFlags {
-    const val CLICKABLE_ROUTE_DETAIL_STOPS = true
+    const val ROUTE_DETAIL_CLICKABLE_STOPS = true
     const val ROUTE_DETAIL_HIGHLIGHT_SOURCE_STOP = true
+    const val ROUTE_DETAIL_PREVENT_ZOOM_WHEN_HAVE_SOURCE_STOP = true
 }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
@@ -4,5 +4,6 @@ object FeatureFlags {
     const val ROUTE_DETAIL_CLICKABLE_STOPS = true
     const val ROUTE_DETAIL_HIGHLIGHT_SOURCE_STOP = true
     const val ROUTE_DETAIL_PREVENT_ZOOM_WHEN_HAVE_SOURCE_STOP = true
+    const val ROUTE_DETAIL_NEAREST_STOP = true
     const val STOP_DETAIL_SHOW_IN_MAPS_BUTTON = true
 }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
@@ -1,0 +1,5 @@
+package cl.emilym.sinatra
+
+object FeatureFlags {
+    const val CLICKABLE_ROUTE_DETAIL_STOPS = true
+}

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
@@ -3,7 +3,7 @@ package cl.emilym.sinatra
 object FeatureFlags {
     const val ROUTE_DETAIL_CLICKABLE_STOPS = true
     const val ROUTE_DETAIL_HIGHLIGHT_SOURCE_STOP = true
-    const val ROUTE_DETAIL_PREVENT_ZOOM_WHEN_HAVE_SOURCE_STOP = true
+    const val ROUTE_DETAIL_PREVENT_ZOOM_WHEN_HAVE_SOURCE_STOP = false
     const val ROUTE_DETAIL_NEAREST_STOP = true
     const val STOP_DETAIL_SHOW_IN_MAPS_BUTTON = true
     const val MAP_SEARCH_SCREEN_NEARBY_STOPS_SEARCH = true

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
@@ -4,4 +4,5 @@ object FeatureFlags {
     const val ROUTE_DETAIL_CLICKABLE_STOPS = true
     const val ROUTE_DETAIL_HIGHLIGHT_SOURCE_STOP = true
     const val ROUTE_DETAIL_PREVENT_ZOOM_WHEN_HAVE_SOURCE_STOP = true
+    const val STOP_DETAIL_SHOW_IN_MAPS_BUTTON = true
 }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
@@ -2,4 +2,5 @@ package cl.emilym.sinatra
 
 object FeatureFlags {
     const val CLICKABLE_ROUTE_DETAIL_STOPS = true
+    const val ROUTE_DETAIL_HIGHLIGHT_SOURCE_STOP = true
 }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Aliases.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Aliases.kt
@@ -12,10 +12,12 @@ typealias RouteId = String
 typealias RouteCode = String
 typealias ServiceId = String
 typealias TripId = String
+
 typealias Latitude = Double
 typealias Longitude = Double
-typealias Pixel = Int
+typealias Kilometer = Double
 
+typealias Pixel = Int
 typealias Radian = Double
 typealias Degree = Double
 

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Location.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Location.kt
@@ -6,6 +6,7 @@ import cl.emilym.sinatra.asRadians
 import cl.emilym.sinatra.degrees
 import cl.emilym.sinatra.radians
 import kotlin.math.abs
+import kotlin.math.acos
 import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.max
@@ -59,6 +60,8 @@ data class MapRegion(
 
 }
 
+const val EARTH_RADIUS = 6371.0
+
 fun List<MapLocation>.findMidpoint(): MapLocation {
     val latR = map { it.lat.degrees.asRadians }
     val lngR = map { it.lng.degrees.asRadians }
@@ -76,6 +79,13 @@ fun List<MapLocation>.findMidpoint(): MapLocation {
     val oLat = atan2(z,hyp)
 
     return MapLocation(oLat.radians.asDegrees, oLng.radians.asDegrees)
+}
+
+fun distance(m1: MapLocation, m2: MapLocation): Double {
+    return acos(
+        (sin(m1.lat.asRadians) * sin(m2.lat.asRadians)) +
+                (cos(m1.lat.asRadians) * cos(m2.lat.asRadians) * cos(m2.lng.asRadians - m1.lng.asRadians))) *
+            EARTH_RADIUS
 }
 
 data class ScreenLocation(

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Stop.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Stop.kt
@@ -38,6 +38,11 @@ data class Stop(
 
 }
 
+data class NearestStop(
+    val stop: Stop,
+    val distance: Kilometer
+)
+
 data class StopAccessibility(
     val wheelchair: StopWheelchairAccessibility
 ) {

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Stop.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Stop.kt
@@ -38,7 +38,7 @@ data class Stop(
 
 }
 
-data class NearestStop(
+data class StopWithDistance(
     val stop: Stop,
     val distance: Kilometer
 )

--- a/ui/src/androidMain/kotlin/cl/emilym/sinatra/ui/Extensions.android.kt
+++ b/ui/src/androidMain/kotlin/cl/emilym/sinatra/ui/Extensions.android.kt
@@ -6,6 +6,9 @@ import cl.emilym.sinatra.data.models.MapRegion
 import cl.emilym.sinatra.data.models.ScreenLocation
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.LatLngBounds
+import org.jetbrains.compose.resources.StringResource
+import sinatra.ui.generated.resources.Res
+import sinatra.ui.generated.resources.open_maps_android
 
 fun MapLocation.toNative(): LatLng {
     return LatLng(
@@ -41,3 +44,6 @@ fun LatLngBounds.toShared(): MapRegion {
         MapLocation(southwest.latitude, northeast.longitude),
     )
 }
+
+internal actual val Res.string.open_maps: StringResource
+    get() = Res.string.open_maps_android

--- a/ui/src/androidMain/kotlin/cl/emilym/sinatra/ui/widgets/OpenMapsPlatform.android.kt
+++ b/ui/src/androidMain/kotlin/cl/emilym/sinatra/ui/widgets/OpenMapsPlatform.android.kt
@@ -1,0 +1,13 @@
+package cl.emilym.sinatra.ui.widgets
+
+import androidx.compose.ui.platform.UriHandler
+import cl.emilym.gtfs.Location
+import cl.emilym.sinatra.data.models.MapLocation
+
+actual fun openMaps(
+    uriHandler: UriHandler,
+    to: MapLocation,
+    from: MapLocation?
+) {
+    uriHandler.openUri("google.navigation:q=${to.lat},${to.lng}")
+}

--- a/ui/src/commonMain/composeResources/values/strings.xml
+++ b/ui/src/commonMain/composeResources/values/strings.xml
@@ -8,6 +8,9 @@
     <string name="about_app_description">Sinatra is a companion app for the Canberra MyWay+ network made by locals for locals. We aim to provide a simpler experience for finding route and stop information, motivated by the suboptimal flow on the official app. We are unfortunately unable to offer the ticketing feature, nor proper routing.\n\n\nSinatra is open source! You can find and contribute to our codebase at [Github](https://github.com/emilymclean/sinatra).</string>
     <string name="about_app_version">Version %1$s (%2$s)</string>
 
+    <string name="open_maps_android">Show in Google Maps</string>
+    <string name="open_maps_ios">Show in Apple Maps</string>
+
     <string name="search_recently_viewed">Recently viewed</string>
     <string name="search_hint">Search for a stop or route.</string>
     <string name="no_search_results">We couldn't find anything for "%1$s".</string>

--- a/ui/src/commonMain/composeResources/values/strings.xml
+++ b/ui/src/commonMain/composeResources/values/strings.xml
@@ -16,11 +16,14 @@
     <plurals name="distance_kilometer">
         <item quantity="one">%1$d kilometer</item>
         <item quantity="other">%1$d kilometers</item>
+        <item quantity="other">%1$d kilometers</item>
     </plurals>
     <plurals name="distance_meter">
         <item quantity="one">%1$d meter</item>
         <item quantity="other">%1$d meters</item>
     </plurals>
+
+    <string name="map_search_nearby_stops">Nearby Stops</string>
 
     <string name="search_recently_viewed">Recently viewed</string>
     <string name="search_hint">Search for a stop or route.</string>

--- a/ui/src/commonMain/composeResources/values/strings.xml
+++ b/ui/src/commonMain/composeResources/values/strings.xml
@@ -11,6 +11,17 @@
     <string name="open_maps_android">Show in Google Maps</string>
     <string name="open_maps_ios">Show in Apple Maps</string>
 
+    <string name="stop_detail_nearest_stop">Nearest Stop</string>
+    <string name="stop_detail_distance">%1$s away</string>
+    <plurals name="distance_kilometer">
+        <item quantity="one">%1$d kilometer</item>
+        <item quantity="other">%1$d kilometers</item>
+    </plurals>
+    <plurals name="distance_meter">
+        <item quantity="one">%1$d meter</item>
+        <item quantity="other">%1$d meters</item>
+    </plurals>
+
     <string name="search_recently_viewed">Recently viewed</string>
     <string name="search_hint">Search for a stop or route.</string>
     <string name="no_search_results">We couldn't find anything for "%1$s".</string>

--- a/ui/src/commonMain/composeResources/values/strings.xml
+++ b/ui/src/commonMain/composeResources/values/strings.xml
@@ -29,7 +29,7 @@
     <string name="route_heading">Towards %1$s</string>
     <string name="route_code_name">Route %1$s</string>
     <string name="upcoming_vehicles">Upcoming routes</string>
-    <string name="no_upcoming_vehicles">There a no routes scheduled.</string>
+    <string name="no_upcoming_vehicles">There are no routes scheduled for the rest of today.</string>
 
     <string name="accessibility_wheelchair_accessible">Wheelchair accessible</string>
     <string name="accessibility_not_wheelchair_accessible">Not wheelchair accessible</string>

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/Consts.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/Consts.kt
@@ -28,3 +28,5 @@ val dayOfWeekDateTimeFormat = LocalDateTime.Format {
     chars(", ")
     time(timeFormat)
 }
+
+const val NEAREST_STOP_RADIUS = 1.0

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/Extensions.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/Extensions.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.graphics.Color
 import cl.emilym.sinatra.asRadians
 import cl.emilym.sinatra.data.models.ColorPair
 import cl.emilym.sinatra.data.models.CoordinateSpan
+import cl.emilym.sinatra.data.models.Kilometer
 import cl.emilym.sinatra.data.models.Latitude
 import cl.emilym.sinatra.data.models.MapLocation
 import cl.emilym.sinatra.data.models.MapRegion
@@ -22,10 +23,15 @@ import cl.emilym.sinatra.degrees
 import cl.emilym.sinatra.ui.widgets.toTodayInstant
 import kotlinx.datetime.Instant
 import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.pluralStringResource
+import org.jetbrains.compose.resources.stringResource
 import sinatra.ui.generated.resources.Res
+import sinatra.ui.generated.resources.distance_kilometer
+import sinatra.ui.generated.resources.distance_meter
 import kotlin.math.cos
 import kotlin.math.ln
 import kotlin.math.pow
+import kotlin.math.roundToInt
 
 fun String.toColor(): Color {
     val trimmed = removePrefix("#")
@@ -129,3 +135,17 @@ fun MapLocation.addCoordinateSpan(span: CoordinateSpan): MapRegion {
 }
 
 internal expect val Res.string.open_maps: StringResource
+
+
+val Kilometer.text
+    @Composable
+    get() = when {
+        this < 1 -> {
+            val meters = (this * 1000).roundToInt()
+            pluralStringResource(Res.plurals.distance_meter, meters, meters)
+        }
+        else -> {
+            val kilometers = roundToInt()
+            pluralStringResource(Res.plurals.distance_kilometer, kilometers, kilometers)
+        }
+    }

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/Extensions.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/Extensions.kt
@@ -21,6 +21,8 @@ import cl.emilym.sinatra.data.models.forDay
 import cl.emilym.sinatra.degrees
 import cl.emilym.sinatra.ui.widgets.toTodayInstant
 import kotlinx.datetime.Instant
+import org.jetbrains.compose.resources.StringResource
+import sinatra.ui.generated.resources.Res
 import kotlin.math.cos
 import kotlin.math.ln
 import kotlin.math.pow
@@ -125,3 +127,5 @@ fun MapLocation.addCoordinateSpan(span: CoordinateSpan): MapRegion {
         )
     )
 }
+
+internal expect val Res.string.open_maps: StringResource

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/maps/MarkerIcon.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/maps/MarkerIcon.kt
@@ -51,6 +51,6 @@ fun routeStopMarkerIcon(route: Route): MarkerIcon {
 @Composable
 fun currentLocationIcon(): MarkerIcon {
     return circularIcon(
-        MaterialTheme.colorScheme.primary,
+        MaterialTheme.colorScheme.secondary,
     )
 }

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/maps/MarkerIcon.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/maps/MarkerIcon.kt
@@ -39,6 +39,11 @@ fun stopMarkerIcon(stop: Stop? = null): MarkerIcon? {
 }
 
 @Composable
+fun highlightedRouteStopMarkerIcon(route: Route, stop: Stop? = null): MarkerIcon? {
+    return spotMarkerIcon(route.color())
+}
+
+@Composable
 fun routeStopMarkerIcon(route: Route): MarkerIcon {
     return circularIcon(route.color(), size = 8.dp, borderWidth = 2.dp)
 }

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/RouteDetailScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/RouteDetailScreen.kt
@@ -41,6 +41,7 @@ import cl.emilym.sinatra.data.models.ServiceBikesAllowed
 import cl.emilym.sinatra.data.models.ServiceId
 import cl.emilym.sinatra.data.models.ServiceWheelchairAccessible
 import cl.emilym.sinatra.data.models.StationTime
+import cl.emilym.sinatra.data.models.StopId
 import cl.emilym.sinatra.data.models.TripId
 import cl.emilym.sinatra.data.repository.FavouriteRepository
 import cl.emilym.sinatra.data.repository.RecentVisitRepository
@@ -54,7 +55,9 @@ import cl.emilym.sinatra.ui.current
 import cl.emilym.sinatra.ui.maps.LineItem
 import cl.emilym.sinatra.ui.maps.MapItem
 import cl.emilym.sinatra.ui.maps.MarkerItem
+import cl.emilym.sinatra.ui.maps.highlightedRouteStopMarkerIcon
 import cl.emilym.sinatra.ui.maps.routeStopMarkerIcon
+import cl.emilym.sinatra.ui.maps.spotMarkerIcon
 import cl.emilym.sinatra.ui.navigation.LocalBottomSheetState
 import cl.emilym.sinatra.ui.navigation.MapScreen
 import cl.emilym.sinatra.ui.past
@@ -130,7 +133,8 @@ class RouteDetailViewModel(
 class RouteDetailScreen(
     private val routeId: RouteId,
     private val serviceId: ServiceId? = null,
-    private val tripId: TripId? = null
+    private val tripId: TripId? = null,
+    private val stopId: StopId? = null,
 ): MapScreen {
     override val key: ScreenKey = "${this::class.qualifiedName!!}/$routeId/$serviceId/$tripId"
 
@@ -335,7 +339,10 @@ class RouteDetailScreen(
         ) + stops.mapNotNull {
             MarkerItem(
                 it.stop?.location ?: return@mapNotNull null,
-                icon,
+                when (it.stopId == stopId && FeatureFlags.ROUTE_DETAIL_HIGHLIGHT_SOURCE_STOP) {
+                    true -> highlightedRouteStopMarkerIcon(route)
+                    false -> icon
+                },
                 id = "routeDetail-${it.stopId}",
                 onClick = when (FeatureFlags.CLICKABLE_ROUTE_DETAIL_STOPS) {
                     true -> { { navigator.push(StopDetailScreen(it.stopId)) } }

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/RouteDetailScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/RouteDetailScreen.kt
@@ -31,6 +31,7 @@ import cl.emilym.compose.requeststate.RequestState
 import cl.emilym.compose.requeststate.RequestStateWidget
 import cl.emilym.compose.requeststate.handle
 import cl.emilym.compose.units.rdp
+import cl.emilym.sinatra.FeatureFlags
 import cl.emilym.sinatra.bounds
 import cl.emilym.sinatra.data.models.Route
 import cl.emilym.sinatra.data.models.RouteId
@@ -318,6 +319,7 @@ class RouteDetailScreen(
     @Composable
     override fun mapItems(): List<MapItem> {
         val viewModel = koinViewModel<RouteDetailViewModel>()
+        val navigator = LocalNavigator.currentOrThrow
         val tripInformationRS by viewModel.tripInformation.collectAsState(RequestState.Initial())
         val info = (tripInformationRS as? RequestState.Success)?.value ?: return listOf()
         val route = info.route
@@ -335,6 +337,10 @@ class RouteDetailScreen(
                 it.stop?.location ?: return@mapNotNull null,
                 icon,
                 id = "routeDetail-${it.stopId}",
+                onClick = when (FeatureFlags.CLICKABLE_ROUTE_DETAIL_STOPS) {
+                    true -> { { navigator.push(StopDetailScreen(it.stopId)) } }
+                    false -> null
+                }
             )
         }
     }

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/RouteDetailScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/RouteDetailScreen.kt
@@ -31,11 +31,10 @@ import cl.emilym.compose.requeststate.RequestState
 import cl.emilym.compose.requeststate.RequestStateWidget
 import cl.emilym.compose.requeststate.handle
 import cl.emilym.compose.units.rdp
-import cl.emilym.gtfs.Location
 import cl.emilym.sinatra.FeatureFlags
 import cl.emilym.sinatra.bounds
 import cl.emilym.sinatra.data.models.MapLocation
-import cl.emilym.sinatra.data.models.NearestStop
+import cl.emilym.sinatra.data.models.StopWithDistance
 import cl.emilym.sinatra.data.models.Route
 import cl.emilym.sinatra.data.models.RouteId
 import cl.emilym.sinatra.data.models.RouteTripInformation
@@ -44,7 +43,6 @@ import cl.emilym.sinatra.data.models.ServiceBikesAllowed
 import cl.emilym.sinatra.data.models.ServiceId
 import cl.emilym.sinatra.data.models.ServiceWheelchairAccessible
 import cl.emilym.sinatra.data.models.StationTime
-import cl.emilym.sinatra.data.models.Stop
 import cl.emilym.sinatra.data.models.StopId
 import cl.emilym.sinatra.data.models.TripId
 import cl.emilym.sinatra.data.models.distance
@@ -84,7 +82,6 @@ import cl.emilym.sinatra.ui.widgets.currentLocation
 import cl.emilym.sinatra.ui.widgets.toIntPx
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.launch
@@ -116,10 +113,10 @@ class RouteDetailViewModel(
     private var lastLocation = MutableStateFlow<MapLocation?>(null)
     val tripInformation = MutableStateFlow<RequestState<CurrentTripInformation?>>(RequestState.Initial())
     val favourited = MutableStateFlow(false)
-    val nearestStop: Flow<NearestStop?> = tripInformation.combine(lastLocation) { tripInformation, lastLocation ->
+    val nearestStop: Flow<StopWithDistance?> = tripInformation.combine(lastLocation) { tripInformation, lastLocation ->
         if (tripInformation !is RequestState.Success || lastLocation == null) return@combine null
         val stops = tripInformation.value?.tripInformation?.stops?.mapNotNull { it.stop }?.nullIfEmpty() ?: return@combine null
-        stops.map { NearestStop(it, distance(lastLocation, it.location)) }
+        stops.map { StopWithDistance(it, distance(lastLocation, it.location)) }
             .filter { it.distance < NEAREST_STOP_RADIUS }
             .nullIfEmpty()
             ?.minBy { it.distance }

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/RouteDetailScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/RouteDetailScreen.kt
@@ -135,7 +135,7 @@ class RouteDetailScreen(
     private val tripId: TripId? = null,
     private val stopId: StopId? = null,
 ): MapScreen {
-    override val key: ScreenKey = "${this::class.qualifiedName!!}/$routeId/$serviceId/$tripId"
+    override val key: ScreenKey = "${this::class.qualifiedName!!}/$routeId/$serviceId/$tripId/$stopId"
 
     @Composable
     override fun Content() {}
@@ -341,7 +341,7 @@ class RouteDetailScreen(
             MarkerItem(
                 it.stop?.location ?: return@mapNotNull null,
                 when (it.stopId == stopId && FeatureFlags.ROUTE_DETAIL_HIGHLIGHT_SOURCE_STOP) {
-                    true -> highlightedRouteStopMarkerIcon(route)
+                    true -> highlightedRouteStopMarkerIcon(route, it.stop)
                     false -> icon
                 },
                 id = "routeDetail-${it.stopId}",

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/RouteDetailScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/RouteDetailScreen.kt
@@ -57,7 +57,6 @@ import cl.emilym.sinatra.ui.maps.MapItem
 import cl.emilym.sinatra.ui.maps.MarkerItem
 import cl.emilym.sinatra.ui.maps.highlightedRouteStopMarkerIcon
 import cl.emilym.sinatra.ui.maps.routeStopMarkerIcon
-import cl.emilym.sinatra.ui.maps.spotMarkerIcon
 import cl.emilym.sinatra.ui.navigation.LocalBottomSheetState
 import cl.emilym.sinatra.ui.navigation.MapScreen
 import cl.emilym.sinatra.ui.past
@@ -214,6 +213,8 @@ class RouteDetailScreen(
 
         val zoomPadding = 4.rdp.toIntPx()
         LaunchedEffect(info.stops) {
+            if (FeatureFlags.ROUTE_DETAIL_PREVENT_ZOOM_WHEN_HAVE_SOURCE_STOP && stopId != null)
+                return@LaunchedEffect
             mapControl.zoomToArea(info.stops.mapNotNull { it.stop?.location }.bounds(), zoomPadding)
         }
 
@@ -344,7 +345,7 @@ class RouteDetailScreen(
                     false -> icon
                 },
                 id = "routeDetail-${it.stopId}",
-                onClick = when (FeatureFlags.CLICKABLE_ROUTE_DETAIL_STOPS) {
+                onClick = when (FeatureFlags.ROUTE_DETAIL_CLICKABLE_STOPS) {
                     true -> { { navigator.push(StopDetailScreen(it.stopId)) } }
                     false -> null
                 }

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/StopDetailScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/StopDetailScreen.kt
@@ -8,9 +8,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -20,6 +22,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import cafe.adriel.voyager.core.screen.ScreenKey
@@ -31,6 +34,7 @@ import cl.emilym.compose.requeststate.RequestState
 import cl.emilym.compose.requeststate.RequestStateWidget
 import cl.emilym.compose.requeststate.handle
 import cl.emilym.compose.units.rdp
+import cl.emilym.sinatra.FeatureFlags
 import cl.emilym.sinatra.data.models.StationTime
 import cl.emilym.sinatra.data.models.Stop
 import cl.emilym.sinatra.data.models.StopId
@@ -44,16 +48,19 @@ import cl.emilym.sinatra.ui.maps.MarkerItem
 import cl.emilym.sinatra.ui.maps.stopMarkerIcon
 import cl.emilym.sinatra.ui.navigation.LocalBottomSheetState
 import cl.emilym.sinatra.ui.navigation.MapScreen
+import cl.emilym.sinatra.ui.open_maps
 import cl.emilym.sinatra.ui.widgets.AccessibilityIconLockup
 import cl.emilym.sinatra.ui.widgets.FavouriteButton
 import cl.emilym.sinatra.ui.widgets.ListHint
 import cl.emilym.sinatra.ui.widgets.LocalMapControl
+import cl.emilym.sinatra.ui.widgets.MapIcon
 import cl.emilym.sinatra.ui.widgets.NoBusIcon
 import cl.emilym.sinatra.ui.widgets.SheetIosBackButton
 import cl.emilym.sinatra.ui.widgets.UpcomingRouteCard
 import cl.emilym.sinatra.ui.widgets.WheelchairAccessibleIcon
 import cl.emilym.sinatra.ui.widgets.createRequestStateFlowFlow
 import cl.emilym.sinatra.ui.widgets.handleFlowProperly
+import cl.emilym.sinatra.ui.widgets.openMaps
 import cl.emilym.sinatra.ui.widgets.presentable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emitAll
@@ -68,6 +75,7 @@ import sinatra.ui.generated.resources.accessibility_wheelchair_accessible
 import sinatra.ui.generated.resources.no_upcoming_vehicles
 import sinatra.ui.generated.resources.stop_not_found
 import sinatra.ui.generated.resources.upcoming_vehicles
+import sinatra.ui.generated.resources.open_maps_android
 
 @KoinViewModel
 class StopDetailViewModel(
@@ -192,6 +200,19 @@ class StopDetailScreen(
                                             true -> stringResource(Res.string.accessibility_wheelchair_accessible)
                                             false -> stringResource(Res.string.accessibility_not_wheelchair_accessible)
                                         })
+                                    }
+                                }
+                            }
+                            if (FeatureFlags.STOP_DETAIL_SHOW_IN_MAPS_BUTTON) {
+                                item {
+                                    val uriHandler = LocalUriHandler.current
+                                    Button(
+                                        onClick = { openMaps(uriHandler, stop.location) },
+                                        modifier = Modifier.fillMaxWidth().padding(horizontal = 1.rdp)
+                                    ) {
+                                        MapIcon()
+                                        Box(Modifier.width(0.5.rdp))
+                                        Text(stringResource(Res.string.open_maps))
                                     }
                                 }
                             }

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/StopDetailScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/StopDetailScreen.kt
@@ -255,7 +255,7 @@ class StopDetailScreen(
                             StationTime.Scheduled(it.arrivalTime),
                             modifier = Modifier.fillMaxWidth(),
                             onClick = { navigator.push(RouteDetailScreen(
-                                it.routeId, it.serviceId, it.tripId
+                                it.routeId, it.serviceId, it.tripId, stopId
                             )) }
                         )
                     }

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/MapSearchScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/MapSearchScreen.kt
@@ -34,7 +34,7 @@ import cl.emilym.sinatra.ui.widgets.currentLocation
 import cl.emilym.sinatra.ui.widgets.viewportHeight
 import org.koin.compose.viewmodel.koinViewModel
 
-val zoomThreshold = 14f
+const val zoomThreshold = 14f
 
 class MapSearchScreen: MapScreen, NativeMapScreen {
     override val key: ScreenKey = this::class.qualifiedName!!
@@ -55,12 +55,11 @@ class MapSearchScreen: MapScreen, NativeMapScreen {
         }
 
         LaunchedEffect(currentLocation) {
-            currentLocation?.let { currentLocation ->
-                if (!viewModel.hasZoomedToLocation) {
-                    mapControl.zoomToPoint(currentLocation)
-                    viewModel.hasZoomedToLocation = true
-                }
-            }
+            val currentLocation = currentLocation ?: return@LaunchedEffect
+            if (viewModel.hasZoomedToLocation) return@LaunchedEffect
+
+            mapControl.zoomToPoint(currentLocation, zoomThreshold + 2f)
+            viewModel.hasZoomedToLocation = true
         }
 
         val halfScreen = viewportHeight() * bottomSheetHalfHeight

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/MapSearchScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/MapSearchScreen.kt
@@ -35,6 +35,7 @@ import cl.emilym.sinatra.ui.widgets.viewportHeight
 import org.koin.compose.viewmodel.koinViewModel
 
 const val zoomThreshold = 14f
+const val currentLocationZoom = zoomThreshold + 4f
 
 class MapSearchScreen: MapScreen, NativeMapScreen {
     override val key: ScreenKey = this::class.qualifiedName!!
@@ -58,7 +59,7 @@ class MapSearchScreen: MapScreen, NativeMapScreen {
             val currentLocation = currentLocation ?: return@LaunchedEffect
             if (viewModel.hasZoomedToLocation) return@LaunchedEffect
 
-            mapControl.zoomToPoint(currentLocation, zoomThreshold + 2f)
+            mapControl.zoomToPoint(currentLocation, currentLocationZoom)
             viewModel.hasZoomedToLocation = true
         }
 
@@ -74,7 +75,7 @@ class MapSearchScreen: MapScreen, NativeMapScreen {
                 currentLocation?.let {
                     FloatingActionButton(
                         onClick = {
-                            mapControl.zoomToPoint(it)
+                            mapControl.zoomToPoint(it, currentLocationZoom)
                         }
                     ) { MyLocationIcon() }
                 }

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/MapSearchScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/MapSearchScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.ScreenKey
 import cl.emilym.compose.requeststate.RequestState
 import cl.emilym.compose.units.rdp
+import cl.emilym.sinatra.FeatureFlags
 import cl.emilym.sinatra.data.models.Stop
 import cl.emilym.sinatra.ui.maps.MapItem
 import cl.emilym.sinatra.ui.maps.MarkerItem
@@ -57,10 +58,13 @@ class MapSearchScreen: MapScreen, NativeMapScreen {
 
         LaunchedEffect(currentLocation) {
             val currentLocation = currentLocation ?: return@LaunchedEffect
-            if (viewModel.hasZoomedToLocation) return@LaunchedEffect
-
-            mapControl.zoomToPoint(currentLocation, currentLocationZoom)
-            viewModel.hasZoomedToLocation = true
+            if (!viewModel.hasZoomedToLocation) {
+                mapControl.zoomToPoint(currentLocation, currentLocationZoom)
+                viewModel.hasZoomedToLocation = true
+            }
+            if (FeatureFlags.MAP_SEARCH_SCREEN_NEARBY_STOPS_SEARCH) {
+                viewModel.updateLocation(currentLocation)
+            }
         }
 
         val halfScreen = viewportHeight() * bottomSheetHalfHeight

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/MapSearchScreenSearchState.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/MapSearchScreenSearchState.kt
@@ -29,11 +29,14 @@ import cafe.adriel.voyager.navigator.currentOrThrow
 import cl.emilym.compose.requeststate.RequestState
 import cl.emilym.compose.requeststate.RequestStateWidget
 import cl.emilym.compose.units.rdp
+import cl.emilym.sinatra.FeatureFlags
 import cl.emilym.sinatra.data.models.RecentVisit
 import cl.emilym.sinatra.domain.search.SearchResult
+import cl.emilym.sinatra.nullIfEmpty
 import cl.emilym.sinatra.ui.navigation.LocalBottomSheetState
 import cl.emilym.sinatra.ui.presentation.screens.maps.RouteDetailScreen
 import cl.emilym.sinatra.ui.presentation.screens.maps.StopDetailScreen
+import cl.emilym.sinatra.ui.text
 import cl.emilym.sinatra.ui.widgets.IosBackButton
 import cl.emilym.sinatra.ui.widgets.ListHint
 import cl.emilym.sinatra.ui.widgets.NoResultsIcon
@@ -48,6 +51,8 @@ import sinatra.ui.generated.resources.Res
 import sinatra.ui.generated.resources.no_search_results
 import sinatra.ui.generated.resources.search_hint
 import sinatra.ui.generated.resources.search_recently_viewed
+import sinatra.ui.generated.resources.map_search_nearby_stops
+import sinatra.ui.generated.resources.stop_detail_distance
 
 @Composable
 fun MapSearchScreenSearchState() {
@@ -60,6 +65,7 @@ fun MapSearchScreenSearchState() {
     val results = (state as? MapSearchState.Search)?.results ?: return
 
     val recentlyViewed by viewModel.recentVisits.collectAsState(RequestState.Initial())
+    val nearbyStops by viewModel.nearbyStops.collectAsState(null)
 
     LaunchedEffect(Unit) {
         bottomSheetState.expand()
@@ -103,30 +109,51 @@ fun MapSearchScreenSearchState() {
                 focusRequester.requestFocus()
             }
         }
+        val hasRecentlyViewed = recentlyViewed is RequestState.Success &&
+                !(recentlyViewed as? RequestState.Success)?.value.isNullOrEmpty()
         when {
-            query.isNullOrBlank() &&
-                    recentlyViewed is RequestState.Success &&
-                    !(recentlyViewed as? RequestState.Success)?.value.isNullOrEmpty() -> {
+            query.isNullOrBlank()-> {
                 item {
                     Box(Modifier.height(1.rdp))
                 }
-                item {
-                    Subheading(stringResource(Res.string.search_recently_viewed))
-                }
-                items((recentlyViewed as? RequestState.Success)?.value ?: listOf()) {
-                    when (it) {
-                        is RecentVisit.Stop -> StopCard(
+                nearbyStops?.nullIfEmpty()?.let { nearbyStops ->
+                    if (!FeatureFlags.MAP_SEARCH_SCREEN_NEARBY_STOPS_SEARCH) return@let
+                    item {
+                        Subheading(stringResource(Res.string.map_search_nearby_stops))
+                    }
+                    items(nearbyStops) {
+                        StopCard(
                             it.stop,
-                            arrival = null,
                             modifier = Modifier.fillMaxWidth(),
-                            onClick = { navigator.push(StopDetailScreen(it.stop.id)) }
+                            onClick = { navigator.push(StopDetailScreen(it.stop.id)) },
+                            subtitle = stringResource(Res.string.stop_detail_distance, it.distance.text)
                         )
+                    }
+                    if (hasRecentlyViewed) {
+                        item {
+                            Box(Modifier.height(1.rdp))
+                        }
+                    }
+                }
+                if (hasRecentlyViewed) {
+                    item {
+                        Subheading(stringResource(Res.string.search_recently_viewed))
+                    }
+                    items((recentlyViewed as? RequestState.Success)?.value ?: listOf()) {
+                        when (it) {
+                            is RecentVisit.Stop -> StopCard(
+                                it.stop,
+                                arrival = null,
+                                modifier = Modifier.fillMaxWidth(),
+                                onClick = { navigator.push(StopDetailScreen(it.stop.id)) }
+                            )
 
-                        is RecentVisit.Route -> RouteCard(
-                            it.route,
-                            modifier = Modifier.fillMaxWidth(),
-                            onClick = { navigator.push(RouteDetailScreen(it.route.id)) }
-                        )
+                            is RecentVisit.Route -> RouteCard(
+                                it.route,
+                                modifier = Modifier.fillMaxWidth(),
+                                onClick = { navigator.push(RouteDetailScreen(it.route.id)) }
+                            )
+                        }
                     }
                 }
             }

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/OpenMapsPlatform.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/OpenMapsPlatform.kt
@@ -1,0 +1,6 @@
+package cl.emilym.sinatra.ui.widgets
+
+import androidx.compose.ui.platform.UriHandler
+import cl.emilym.sinatra.data.models.MapLocation
+
+expect fun openMaps(uriHandler: UriHandler, to: MapLocation, from: MapLocation? = null)

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/StopCard.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/StopCard.kt
@@ -29,7 +29,8 @@ fun StopCard(
     stop: Stop,
     modifier: Modifier = Modifier,
     arrival: StationTime? = null,
-    onClick: (() -> Unit)? = null
+    onClick: (() -> Unit)? = null,
+    subtitle: String? = null
 ) {
     ListCard(
         {},
@@ -59,6 +60,12 @@ fun StopCard(
                     is StationTime.Scheduled -> stringResource(Res.string.scheduled_arrival, time)
                     is StationTime.Live -> stringResource(Res.string.estimated_arrival, time)
                 },
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
+        if (subtitle != null) {
+            Text(
+                subtitle,
                 style = MaterialTheme.typography.bodySmall
             )
         }

--- a/ui/src/iosMain/kotlin/cl/emilym/sinatra/ui/Extensions.ios.kt
+++ b/ui/src/iosMain/kotlin/cl/emilym/sinatra/ui/Extensions.ios.kt
@@ -18,6 +18,7 @@ import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.interpretCPointer
 import kotlinx.cinterop.sizeOf
 import kotlinx.cinterop.useContents
+import org.jetbrains.compose.resources.StringResource
 import platform.CoreGraphics.CGPoint
 import platform.CoreGraphics.CGPointMake
 import platform.CoreLocation.CLLocationCoordinate2D
@@ -27,6 +28,8 @@ import platform.MapKit.MKCoordinateSpanMake
 import platform.UIKit.UIColor
 import kotlin.math.pow
 import platform.CoreGraphics.CGColorRef
+import sinatra.ui.generated.resources.Res
+import sinatra.ui.generated.resources.open_maps_ios
 import kotlin.math.ln
 import kotlin.math.log
 
@@ -131,3 +134,6 @@ fun MarkerAnnotation.matches(markerItem: MarkerItem): Boolean {
             markerItem.icon?.reuseIdentifier == icon?.reuseIdentifier &&
             location == markerItem.location
 }
+
+internal actual val Res.string.open_maps: StringResource
+    get() = Res.string.open_maps_ios

--- a/ui/src/iosMain/kotlin/cl/emilym/sinatra/ui/widgets/OpenMapsPlatform.ios.kt
+++ b/ui/src/iosMain/kotlin/cl/emilym/sinatra/ui/widgets/OpenMapsPlatform.ios.kt
@@ -1,0 +1,13 @@
+package cl.emilym.sinatra.ui.widgets
+
+import androidx.compose.ui.platform.UriHandler
+import cl.emilym.gtfs.Location
+import cl.emilym.sinatra.data.models.MapLocation
+
+actual fun openMaps(
+    uriHandler: UriHandler,
+    to: MapLocation,
+    from: MapLocation?
+) {
+    uriHandler.openUri("maps://daddr=${to.lat},${to.lng}")
+}


### PR DESCRIPTION
* Makes stops clickable in route detail view
* Highlights the source stop in route detail view
* Allows zoom to be prevented when viewing a route from a source stop
* Shows nearest stops in route detail view, as well as nearby stops in search screen
* Adds a "show in maps" button to stop detail view