### PR TITLE
Don't reset navigation calculation when user moves

### DIFF
--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/navigate/NavigationEntryViewModel.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/navigate/NavigationEntryViewModel.kt
@@ -246,7 +246,7 @@ class NavigationEntryViewModel(
                 save(navigationLocation.location, false)
             }
             is NavigationLocation.CurrentLocation -> {
-                save(null, true)
+                save(currentLocation, true)
             }
         }
         navigationLocation.recentVisit?.let {

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/navigate/NavigationEntryViewModel.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/navigate/NavigationEntryViewModel.kt
@@ -231,10 +231,10 @@ class NavigationEntryViewModel(
     fun updateCurrentLocation(location: MapLocation) {
         lastLocation.value = location
         val currentLocation = currentLocation
-        if (currentLocation != null && distance(location, currentLocation) < 1.0) return
+//        if (currentLocation != null && distance(location, currentLocation) < 1.0) return
         this.currentLocation = location
-        if (originCurrentLocation) _origin = location
-        if (destinationCurrentLocation) _destination = location
+        if (originCurrentLocation && _origin == null) _origin = location
+        if (destinationCurrentLocation && _destination == null) _destination = location
     }
 
     private fun unpackLocation(
@@ -246,7 +246,7 @@ class NavigationEntryViewModel(
                 save(navigationLocation.location, false)
             }
             is NavigationLocation.CurrentLocation -> {
-                save(currentLocation, true)
+                save(null, true)
             }
         }
         navigationLocation.recentVisit?.let {


### PR DESCRIPTION
Once a proper turn-by-turn navigation screen has been developed this can be reverted. For now, users are expected to follow directions on this screen - directions that will reset as they move without this change!