### PR TITLE
Implement smoother animations relating to the bottom sheet

### DIFF
--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/MapSearchScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/MapSearchScreen.kt
@@ -15,10 +15,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.min
 import cafe.adriel.voyager.core.screen.ScreenKey
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import cl.emilym.compose.requeststate.RequestState
+import cl.emilym.compose.units.px
 import cl.emilym.compose.units.rdp
 import cl.emilym.sinatra.FeatureFlags
 import cl.emilym.sinatra.data.models.Stop
@@ -39,6 +41,7 @@ import cl.emilym.sinatra.ui.widgets.SinatraBackHandler
 import cl.emilym.sinatra.ui.widgets.bottomsheet.SinatraSheetValue
 import cl.emilym.sinatra.ui.widgets.currentLocation
 import cl.emilym.sinatra.ui.widgets.viewportHeight
+import io.github.aakira.napier.Napier
 import org.koin.compose.viewmodel.koinViewModel
 
 const val zoomThreshold = 14f
@@ -68,8 +71,6 @@ class MapSearchScreen: MapScreen, NativeMapScreen {
                 viewModel.updateLocation(currentLocation)
             }
         }
-
-        val halfScreen = viewportHeight() * bottomSheetHalfHeight
         Box(
             Modifier.fillMaxSize(),
             contentAlignment = Alignment.BottomEnd
@@ -92,14 +93,12 @@ class MapSearchScreen: MapScreen, NativeMapScreen {
                         },
                     ) { SearchIcon() }
                 }
-                val sheetValue = LocalBottomSheetState.current.bottomSheetState.currentValue
+                val sheetValue = LocalBottomSheetState.current.bottomSheetState.offset
                 Box(
-                    Modifier.height(
-                        when (sheetValue) {
-                            SinatraSheetValue.PartiallyExpanded -> 56.dp
-                            else -> halfScreen
-                        }
-                    )
+                    Modifier.height(min(
+                        viewportHeight() - (sheetValue?.px ?: 0.dp),
+                        viewportHeight() * bottomSheetHalfHeight
+                    ))
                 )
             }
         }

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/bottomsheet/SinatraBottomSheet.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/bottomsheet/SinatraBottomSheet.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -18,11 +19,14 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.times
+import cl.emilym.compose.units.px
+import cl.emilym.sinatra.ui.widgets.viewportHeight
 import kotlinx.coroutines.launch
 import kotlin.math.abs
 
@@ -33,8 +37,8 @@ fun SinatraBottomSheet(
     calculateAnchors: (sheetSize: IntSize) -> DraggableAnchors<SinatraSheetValue>,
     peekHeight: Dp,
     sheetMaxWidth: Dp,
+    sheetHalfHeight: Float,
     sheetSwipeEnabled: Boolean,
-    shape: Shape,
     containerColor: Color,
     contentColor: Color,
     tonalElevation: Dp,
@@ -45,6 +49,23 @@ fun SinatraBottomSheet(
     val scope = rememberCoroutineScope()
 
     val orientation = Orientation.Vertical
+
+    // Tween corner radius to 0 during swipe between halfHeight and expanded
+    val viewportHeight = viewportHeight()
+    val halfHeight = remember(viewportHeight, sheetHalfHeight) { sheetHalfHeight * viewportHeight }
+    val offsetPx = state.offset?.px ?: 0.dp
+    val corner = remember(halfHeight, offsetPx, viewportHeight) {
+        val adjustedHeight = viewportHeight - halfHeight
+        (1f - ((viewportHeight - offsetPx - halfHeight) / adjustedHeight)).coerceIn(0f, 1f) * 28.dp
+    }
+    val shape = remember(corner) {
+        RoundedCornerShape(
+            corner,
+            corner,
+            0.dp,
+            0.dp
+        )
+    }
 
     Surface(
         modifier = Modifier

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/bottomsheet/SinatraBottomSheetScaffold.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/bottomsheet/SinatraBottomSheetScaffold.kt
@@ -40,7 +40,6 @@ fun SinatraBottomSheetScaffold(
     sheetPeekHeight: Dp = 56.dp,
     sheetHalfHeight: Float = 0.5f,
     sheetMaxWidth: Dp = 640.dp,
-    sheetShape: Shape = MaterialTheme.shapes.extraLarge.copy(bottomStart = CornerSize(0f), bottomEnd = CornerSize(0f)),
     sheetContainerColor: Color = MaterialTheme.colorScheme.surfaceContainer,
     sheetContentColor: Color = contentColorFor(sheetContainerColor),
     sheetTonalElevation: Dp = 1.dp,
@@ -73,6 +72,7 @@ fun SinatraBottomSheetScaffold(
                 state = scaffoldState.bottomSheetState,
                 peekHeight = sheetPeekHeight,
                 sheetMaxWidth = sheetMaxWidth,
+                sheetHalfHeight = sheetHalfHeight,
                 sheetSwipeEnabled = sheetSwipeEnabled,
                 calculateAnchors = { sheetSize ->
                     val sheetHeight = sheetSize.height
@@ -89,7 +89,6 @@ fun SinatraBottomSheetScaffold(
                         SinatraSheetValue.HalfExpanded at maxOf(layoutHeight - (sheetHeight * sheetHalfHeight), 0f)
                     }
                 },
-                shape = sheetShape,
                 containerColor = sheetContainerColor,
                 contentColor = sheetContentColor,
                 tonalElevation = sheetTonalElevation,

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/bottomsheet/SinatraSheetDefaults.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/bottomsheet/SinatraSheetDefaults.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
+import cl.emilym.sinatra.nullIf
 import kotlinx.coroutines.CancellationException
 import kotlin.jvm.JvmName
 
@@ -260,7 +261,7 @@ class SinatraSheetState @OptIn(ExperimentalMaterial3Api::class) constructor(
     )
 
     @OptIn(ExperimentalFoundationApi::class)
-    internal val offset: Float? get() = anchoredDraggableState.offset
+    val offset: Float? get() = anchoredDraggableState.offset.nullIf { it.isNaN() }
 
     internal var density: Density? = null
     private fun requireDensity() = requireNotNull(density) {


### PR DESCRIPTION
Closes #14

* Map actions now smoothly track drawer position, rather than jumping around
* Corner radius of bottom sheet approaches 0 between half and expanded state (used for non-rounded displays so that little bits of the map don't poke out when fully expanded, especially on iOS)