### PR TITLE
Heavily penalize transfers when calculating routes

### DIFF
--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/router/RaptorTest.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/router/RaptorTest.kt
@@ -17,7 +17,9 @@ class RaptorTest {
         const val STOP_ID_SWINDEN_STREET_GGN = "8119"
         const val STOP_ID_SWINDEN_STREET = "SWN"
         const val STOP_ID_MANNING_CLARK_GGN = "8105"
+        const val STOP_ID_MANNING_CLARK_ALG = "8104"
         const val STOP_ID_MANNING_CLARK = "MCK"
+        const val STOP_ID_SANDFORD_STREET_ALG = "8112"
         const val STOP_ID_CANBERRA_RAILWAY_STATION = "3320"
     }
 
@@ -192,6 +194,40 @@ class RaptorTest {
                 STOP_ID_MANNING_CLARK
             )
         }
+    }
+
+    @Test
+    fun testNegativeValueOutcomeJourney() {
+        val raptor = Raptor(
+            graph,
+            listOf(
+                listOf("SA"),
+                listOf("SU"),
+                listOf("WD")
+            ),
+            RaptorConfig(
+                maximumWalkingTime = 25 * 60L,
+                transferPenalty = 10 * 60L,
+                changeOverPenalty = 15 * 60L,
+                penaltyMultiplier = 1000f
+            )
+        )
+        val result = raptor.calculate(
+            Duration.parseIsoString("PT23H55M").inWholeSeconds,
+            STOP_ID_MANNING_CLARK_ALG,
+            STOP_ID_SANDFORD_STREET_ALG,
+        )
+        assertEquals(RaptorJourney(listOf(
+            RaptorJourneyConnection.Travel(
+                listOf("8104", "8106", "8108", "8110", "8112"),
+                "X1",
+                "Sandford St",
+                startTime=86524,
+                endTime=86947,
+                travelTime=423,
+                dayIndex = 0,
+            ),
+        )), result)
     }
 
 }

--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/router/RaptorTest.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/router/RaptorTest.kt
@@ -31,7 +31,8 @@ class RaptorTest {
         config = RaptorConfig(
             maximumWalkingTime = 10 * 60L,
             transferPenalty = 0 * 60L,
-            changeOverPenalty = 0 * 60L
+            changeOverPenalty = 0 * 60L,
+            penaltyMultiplier = 1f
         )
         raptor = Raptor(graph, List(3) { graph.mappings.serviceIds }, config)
     }

--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/router/RaptorTest.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/router/RaptorTest.kt
@@ -1,10 +1,7 @@
 package cl.emilym.sinatra.router
 
-import android.net.Network
 import cl.emilym.sinatra.RouterException
 import cl.emilym.sinatra.router.data.NetworkGraph
-import io.github.aakira.napier.Napier
-import pbandk.decodeFromByteArray
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -32,9 +29,10 @@ class RaptorTest {
         graph = NetworkGraph.byteFormatForByteArray(this::class.java.classLoader.getResource("network_graph.eng").readBytes())
         config = RaptorConfig(
             maximumWalkingTime = 10 * 60L,
-            transferPenalty = 0 * 60L,
-            changeOverPenalty = 0 * 60L,
-            penaltyMultiplier = 1f
+            transferTime = 0,
+            transferPenalty = 0,
+            changeOverTime = 0,
+            changeOverPenalty = 0
         )
         raptor = Raptor(graph, List(3) { graph.mappings.serviceIds }, config)
     }
@@ -185,8 +183,10 @@ class RaptorTest {
         assertFails {
             val raptor = Raptor(graph, List(3) { graph.mappings.serviceIds }, config = RaptorConfig(
                 maximumWalkingTime = 0 * 60L,
-                transferPenalty = 0 * 60L,
-                changeOverPenalty = 0 * 60L
+                transferTime = 0,
+                transferPenalty = 0,
+                changeOverTime = 0,
+                changeOverPenalty = 0
             ))
             raptor.calculate(
                 Duration.parseIsoString("PT25H").inWholeSeconds,
@@ -207,9 +207,10 @@ class RaptorTest {
             ),
             RaptorConfig(
                 maximumWalkingTime = 25 * 60L,
-                transferPenalty = 10 * 60L,
-                changeOverPenalty = 15 * 60L,
-                penaltyMultiplier = 1000f
+                transferTime = 10 * 60L,
+                transferPenalty = 10 * 60 * 1000,
+                changeOverTime = 15 * 60L,
+                changeOverPenalty = 15 * 60 * 1000,
             )
         )
         val result = raptor.calculate(

--- a/shared/src/commonMain/kotlin/cl/emilym/gtfs/gtfs-api.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/gtfs/gtfs-api.kt
@@ -530,6 +530,7 @@ public data class JourneySearchOption(
     val maximumWalkingTime: Int? = null,
     val transferPenalty: Int? = null,
     val changeOverPenalty: Int? = null,
+    val penaltyMultiplier: Double? = null,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
 ) : pbandk.Message {
     override operator fun plus(other: pbandk.Message?): cl.emilym.gtfs.JourneySearchOption = protoMergeImpl(other)
@@ -543,7 +544,7 @@ public data class JourneySearchOption(
             fullName = "proto.JourneySearchOption",
             messageClass = cl.emilym.gtfs.JourneySearchOption::class,
             messageCompanion = this,
-            fields = buildList(3) {
+            fields = buildList(4) {
                 add(
                     pbandk.FieldDescriptor(
                         messageDescriptor = this@Companion::descriptor,
@@ -572,6 +573,16 @@ public data class JourneySearchOption(
                         type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
                         jsonName = "changeOverPenalty",
                         value = cl.emilym.gtfs.JourneySearchOption::changeOverPenalty
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "penaltyMultiplier",
+                        number = 4,
+                        type = pbandk.FieldDescriptor.Type.Primitive.Double(hasPresence = true),
+                        jsonName = "penaltyMultiplier",
+                        value = cl.emilym.gtfs.JourneySearchOption::penaltyMultiplier
                     )
                 )
             }
@@ -1899,6 +1910,7 @@ private fun JourneySearchOption.protoMergeImpl(plus: pbandk.Message?): JourneySe
         maximumWalkingTime = plus.maximumWalkingTime ?: maximumWalkingTime,
         transferPenalty = plus.transferPenalty ?: transferPenalty,
         changeOverPenalty = plus.changeOverPenalty ?: changeOverPenalty,
+        penaltyMultiplier = plus.penaltyMultiplier ?: penaltyMultiplier,
         unknownFields = unknownFields + plus.unknownFields
     )
 } ?: this
@@ -1908,16 +1920,18 @@ private fun JourneySearchOption.Companion.decodeWithImpl(u: pbandk.MessageDecode
     var maximumWalkingTime: Int? = null
     var transferPenalty: Int? = null
     var changeOverPenalty: Int? = null
+    var penaltyMultiplier: Double? = null
 
     val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
         when (_fieldNumber) {
             1 -> maximumWalkingTime = _fieldValue as Int
             2 -> transferPenalty = _fieldValue as Int
             3 -> changeOverPenalty = _fieldValue as Int
+            4 -> penaltyMultiplier = _fieldValue as Double
         }
     }
 
-    return JourneySearchOption(maximumWalkingTime, transferPenalty, changeOverPenalty, unknownFields)
+    return JourneySearchOption(maximumWalkingTime, transferPenalty, changeOverPenalty, penaltyMultiplier, unknownFields)
 }
 
 private fun Stop.protoMergeImpl(plus: pbandk.Message?): Stop = (plus as? Stop)?.let {

--- a/shared/src/commonMain/kotlin/cl/emilym/gtfs/gtfs-api.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/gtfs/gtfs-api.kt
@@ -528,9 +528,10 @@ public data class JourneySearchConfigEndpoint(
 @pbandk.Export
 public data class JourneySearchOption(
     val maximumWalkingTime: Int? = null,
+    val transferTime: Int? = null,
+    val changeOverTime: Int? = null,
     val transferPenalty: Int? = null,
     val changeOverPenalty: Int? = null,
-    val penaltyMultiplier: Double? = null,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
 ) : pbandk.Message {
     override operator fun plus(other: pbandk.Message?): cl.emilym.gtfs.JourneySearchOption = protoMergeImpl(other)
@@ -544,7 +545,7 @@ public data class JourneySearchOption(
             fullName = "proto.JourneySearchOption",
             messageClass = cl.emilym.gtfs.JourneySearchOption::class,
             messageCompanion = this,
-            fields = buildList(4) {
+            fields = buildList(5) {
                 add(
                     pbandk.FieldDescriptor(
                         messageDescriptor = this@Companion::descriptor,
@@ -558,8 +559,28 @@ public data class JourneySearchOption(
                 add(
                     pbandk.FieldDescriptor(
                         messageDescriptor = this@Companion::descriptor,
-                        name = "transferPenalty",
+                        name = "transferTime",
                         number = 2,
+                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
+                        jsonName = "transferTime",
+                        value = cl.emilym.gtfs.JourneySearchOption::transferTime
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "changeOverTime",
+                        number = 3,
+                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
+                        jsonName = "changeOverTime",
+                        value = cl.emilym.gtfs.JourneySearchOption::changeOverTime
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "transferPenalty",
+                        number = 4,
                         type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
                         jsonName = "transferPenalty",
                         value = cl.emilym.gtfs.JourneySearchOption::transferPenalty
@@ -569,20 +590,10 @@ public data class JourneySearchOption(
                     pbandk.FieldDescriptor(
                         messageDescriptor = this@Companion::descriptor,
                         name = "changeOverPenalty",
-                        number = 3,
+                        number = 5,
                         type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
                         jsonName = "changeOverPenalty",
                         value = cl.emilym.gtfs.JourneySearchOption::changeOverPenalty
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "penaltyMultiplier",
-                        number = 4,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Double(hasPresence = true),
-                        jsonName = "penaltyMultiplier",
-                        value = cl.emilym.gtfs.JourneySearchOption::penaltyMultiplier
                     )
                 )
             }
@@ -1908,9 +1919,10 @@ public fun JourneySearchOption?.orDefault(): cl.emilym.gtfs.JourneySearchOption 
 private fun JourneySearchOption.protoMergeImpl(plus: pbandk.Message?): JourneySearchOption = (plus as? JourneySearchOption)?.let {
     it.copy(
         maximumWalkingTime = plus.maximumWalkingTime ?: maximumWalkingTime,
+        transferTime = plus.transferTime ?: transferTime,
+        changeOverTime = plus.changeOverTime ?: changeOverTime,
         transferPenalty = plus.transferPenalty ?: transferPenalty,
         changeOverPenalty = plus.changeOverPenalty ?: changeOverPenalty,
-        penaltyMultiplier = plus.penaltyMultiplier ?: penaltyMultiplier,
         unknownFields = unknownFields + plus.unknownFields
     )
 } ?: this
@@ -1918,20 +1930,23 @@ private fun JourneySearchOption.protoMergeImpl(plus: pbandk.Message?): JourneySe
 @Suppress("UNCHECKED_CAST")
 private fun JourneySearchOption.Companion.decodeWithImpl(u: pbandk.MessageDecoder): JourneySearchOption {
     var maximumWalkingTime: Int? = null
+    var transferTime: Int? = null
+    var changeOverTime: Int? = null
     var transferPenalty: Int? = null
     var changeOverPenalty: Int? = null
-    var penaltyMultiplier: Double? = null
 
     val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
         when (_fieldNumber) {
             1 -> maximumWalkingTime = _fieldValue as Int
-            2 -> transferPenalty = _fieldValue as Int
-            3 -> changeOverPenalty = _fieldValue as Int
-            4 -> penaltyMultiplier = _fieldValue as Double
+            2 -> transferTime = _fieldValue as Int
+            3 -> changeOverTime = _fieldValue as Int
+            4 -> transferPenalty = _fieldValue as Int
+            5 -> changeOverPenalty = _fieldValue as Int
         }
     }
 
-    return JourneySearchOption(maximumWalkingTime, transferPenalty, changeOverPenalty, penaltyMultiplier, unknownFields)
+    return JourneySearchOption(maximumWalkingTime, transferTime, changeOverTime, transferPenalty,
+        changeOverPenalty, unknownFields)
 }
 
 private fun Stop.protoMergeImpl(plus: pbandk.Message?): Stop = (plus as? Stop)?.let {

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Config.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Config.kt
@@ -3,7 +3,6 @@ package cl.emilym.sinatra.data.models
 import cl.emilym.gtfs.JourneySearchConfigEndpoint
 import cl.emilym.sinatra.router.RaptorConfig
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.INFINITE
 import kotlin.time.Duration.Companion.ZERO
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -25,25 +24,30 @@ data class JourneySearchConfig(
 
 data class JourneySearchOption(
     val maximumWalkingTime: Duration,
-    val transferPenalty: Duration,
-    val changeOverPenalty: Duration,
-    val penaltyMultiplier: Double
+    val transferTime: Duration,
+    val transferPenalty: Int,
+    val changeOverTime: Duration,
+    val changeOverPenalty: Int
 ) {
 
     val raptor: RaptorConfig get() = RaptorConfig(
         maximumWalkingTime.inWholeSeconds,
-        transferPenalty.inWholeSeconds,
-        changeOverPenalty.inWholeSeconds,
-        penaltyMultiplier.toFloat()
+        transferTime.inWholeSeconds,
+        transferPenalty,
+        changeOverTime.inWholeSeconds,
+        changeOverPenalty,
     )
 
     companion object {
         fun fromPb(pb: cl.emilym.gtfs.JourneySearchOption): JourneySearchOption {
+            val transferTime = pb.transferTime?.milliseconds ?: ZERO
+            val changeOverTime = pb.changeOverTime?.milliseconds ?: ZERO
             return JourneySearchOption(
                 pb.maximumWalkingTime?.milliseconds ?: ZERO,
-                pb.transferPenalty?.milliseconds ?: ZERO,
-                pb.changeOverPenalty?.milliseconds ?: ZERO,
-                pb.penaltyMultiplier ?: 1000.0
+                transferTime,
+                pb.transferPenalty ?: transferTime.inWholeSeconds.toInt(),
+                changeOverTime,
+                pb.changeOverPenalty ?: changeOverTime.inWholeSeconds.toInt(),
             )
         }
     }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Config.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Config.kt
@@ -26,13 +26,15 @@ data class JourneySearchConfig(
 data class JourneySearchOption(
     val maximumWalkingTime: Duration,
     val transferPenalty: Duration,
-    val changeOverPenalty: Duration
+    val changeOverPenalty: Duration,
+    val penaltyMultiplier: Double
 ) {
 
     val raptor: RaptorConfig get() = RaptorConfig(
         maximumWalkingTime.inWholeSeconds,
         transferPenalty.inWholeSeconds,
-        changeOverPenalty.inWholeSeconds
+        changeOverPenalty.inWholeSeconds,
+        penaltyMultiplier.toFloat()
     )
 
     companion object {
@@ -40,7 +42,8 @@ data class JourneySearchOption(
             return JourneySearchOption(
                 pb.maximumWalkingTime?.milliseconds ?: ZERO,
                 pb.transferPenalty?.milliseconds ?: ZERO,
-                pb.changeOverPenalty?.milliseconds ?: ZERO
+                pb.changeOverPenalty?.milliseconds ?: ZERO,
+                pb.penaltyMultiplier ?: 1000.0
             )
         }
     }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/persistence/NetworkGraphPersistence.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/persistence/NetworkGraphPersistence.kt
@@ -53,20 +53,9 @@ class JourneyConfigPersistence(
                 JourneySearchOption(
                     10.minutes,
                     5.minutes,
+                    5.minutes.inWholeSeconds.toInt(),
                     5.minutes,
-                    1.0,
-                ),
-                JourneySearchOption(
-                    25.minutes,
-                    15.minutes,
-                    25.minutes,
-                    1.0,
-                ),
-                JourneySearchOption(
-                    25.minutes,
-                    10.minutes,
-                    15.minutes,
-                    1.0,
+                    5.minutes.inWholeSeconds.toInt()
                 )
             )
         )

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/persistence/NetworkGraphPersistence.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/persistence/NetworkGraphPersistence.kt
@@ -53,16 +53,16 @@ class JourneyConfigPersistence(
                 JourneySearchOption(
                     10.minutes,
                     5.minutes,
-                    10.minutes.inWholeMilliseconds.toInt(),
+                    5 * 60 * 100,
                     5.minutes,
-                    10.minutes.inWholeMilliseconds.toInt()
+                    5 * 60 * 100
                 ),
                 JourneySearchOption(
                     30.minutes,
                     5.minutes,
-                    10.minutes.inWholeMilliseconds.toInt(),
+                    5 * 60 * 100,
                     5.minutes,
-                    10.minutes.inWholeMilliseconds.toInt()
+                    5 * 60 * 100
                 )
             )
         )

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/persistence/NetworkGraphPersistence.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/persistence/NetworkGraphPersistence.kt
@@ -53,9 +53,16 @@ class JourneyConfigPersistence(
                 JourneySearchOption(
                     10.minutes,
                     5.minutes,
-                    5.minutes.inWholeSeconds.toInt(),
+                    10.minutes.inWholeMilliseconds.toInt(),
                     5.minutes,
-                    5.minutes.inWholeSeconds.toInt()
+                    10.minutes.inWholeMilliseconds.toInt()
+                ),
+                JourneySearchOption(
+                    30.minutes,
+                    5.minutes,
+                    10.minutes.inWholeMilliseconds.toInt(),
+                    5.minutes,
+                    10.minutes.inWholeMilliseconds.toInt()
                 )
             )
         )

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/persistence/NetworkGraphPersistence.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/persistence/NetworkGraphPersistence.kt
@@ -54,16 +54,19 @@ class JourneyConfigPersistence(
                     10.minutes,
                     5.minutes,
                     5.minutes,
+                    1.0,
                 ),
                 JourneySearchOption(
                     25.minutes,
                     15.minutes,
                     25.minutes,
+                    1.0,
                 ),
                 JourneySearchOption(
                     25.minutes,
                     10.minutes,
                     15.minutes,
+                    1.0,
                 )
             )
         )

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/CalculateJourneyUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/CalculateJourneyUseCase.kt
@@ -126,7 +126,7 @@ class CalculateJourneyUseCase(
     }
 
     private suspend fun calculateJourney(
-        config: RaptorConfig?,
+        config: RaptorConfig,
         departureStops: List<RaptorStop>,
         arrivalStops: List<RaptorStop>
     ): Journey? {

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/router/Models.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/router/Models.kt
@@ -8,6 +8,7 @@ import cl.emilym.sinatra.router.data.NetworkGraphNode
 data class NodeCost(
     val index: NodeIndex,
     val cost: Long,
+    val costP: Long,
     val edge: NetworkGraphEdge,
     val dayIndex: Int? = null
 )

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/router/Raptor.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/router/Raptor.kt
@@ -92,17 +92,8 @@ class Raptor(
                 }
                 if (neighbour.edge.type == EdgeType.TRAVEL) {
                     val tV = getNode(neighbour.edge.connectedNodeIndex.toInt()).stopIndex.toInt()
-                    var addedTime = 0L
-                    var addedPenalty = 0L
-                    when (prevEdge[tV]?.type) {
-                        EdgeType.TRAVEL -> when {
-                            getNode(prev[tV]!!).routeIndex != getNode(u).routeIndex -> {
-                                addedTime = config.changeOverTime
-                                addedPenalty = config.changeOverPenalty.toLong()
-                            }
-                        }
-                        else -> {}
-                    }
+                    val addedPenalty = config.changeOverPenalty
+                    val addedTime = config.changeOverTime
                     if ((altP + addedPenalty) < distP[tV]) {
                         prev[tV] = u
                         prevEdge[tV] = neighbour.edge

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/router/Raptor.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/router/Raptor.kt
@@ -88,7 +88,7 @@ class Raptor(
                     distP[v] = altP
                     dist[v] = alt
                     dayIndex[v] = neighbour.dayIndex
-                    Q.add(v, alt)
+                    Q.add(v, altP)
                 }
                 if (neighbour.edge.type == EdgeType.TRAVEL) {
                     val tV = getNode(neighbour.edge.connectedNodeIndex.toInt()).stopIndex.toInt()
@@ -109,7 +109,7 @@ class Raptor(
                         distP[tV] = altP + addedPenalty
                         dist[tV] = alt + addedTime
                         dayIndex[v] = neighbour.dayIndex
-                        Q.add(tV, alt)
+                        Q.add(tV, altP)
                     }
                 }
             }
@@ -210,7 +210,9 @@ class Raptor(
 
         return edges.flatMap {
             when (it.type) {
-                EdgeType.UNWEIGHTED -> listOf(NodeCost(it.connectedNodeIndex.toInt(), 0L, 0L, it, null))
+                EdgeType.UNWEIGHTED -> listOf(
+                    NodeCost(it.connectedNodeIndex.toInt(), 0L, 0L, it, null)
+                )
                 EdgeType.TRANSFER, EdgeType.TRANSFER_NON_ADJUSTABLE -> {
                     if (ignoreTransfer) return@flatMap emptyList()
                     if (it.cost.toLong() > (config.maximumWalkingTime)) return@flatMap emptyList()

--- a/shared/src/commonMain/proto/gtfs-api.proto
+++ b/shared/src/commonMain/proto/gtfs-api.proto
@@ -55,9 +55,10 @@ message JourneySearchConfigEndpoint {
 
 message JourneySearchOption {
   optional int32 maximumWalkingTime = 1;
-  optional int32 transferPenalty = 2;
-  optional int32 changeOverPenalty = 3;
-  optional double penaltyMultiplier = 4;
+  optional int32 transferTime = 2;
+  optional int32 changeOverTime = 3;
+  optional int32 transferPenalty = 4;
+  optional int32 changeOverPenalty = 5;
 }
 
 message Stop {

--- a/shared/src/commonMain/proto/gtfs-api.proto
+++ b/shared/src/commonMain/proto/gtfs-api.proto
@@ -57,6 +57,7 @@ message JourneySearchOption {
   optional int32 maximumWalkingTime = 1;
   optional int32 transferPenalty = 2;
   optional int32 changeOverPenalty = 3;
+  optional double penaltyMultiplier = 4;
 }
 
 message Stop {


### PR DESCRIPTION
Adds a second "penalty" dist tracker that essentially represents travel time + (transfer time penalties * penalty multiplier).

This was introduced to try and prevent the circumstance in which on a hypothetical journey that should travel as such: A -> B -> C, where a vehicle goes between A and B, and another A, B, and then C, if the first vehicle arrives at B sooner, Djikstra will greedily suggest taking vehicle 1 and transferring to vehicle 2 for the remaining journey between B and C.  By more heavily penalising transfers, this behaviour can be largely curtailed
