### PR TITLE
Fix back gesture not exiting app on NavigateEntryScreen

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,16 +1,16 @@
 "feature":
   - head-branch:
-    - "feature/*"
-    - "*/feature/*"
+    - "feature\/.*"
+    - ".*\/feature\/.*"
 
 "bug":
   - head-branch:
-    - "fix/*"
-    - "*/fix/*"
-    - "bug/*"
-    - "*/bug/*"
+    - "fix\/.*"
+    - ".*\/fix\/.*"
+    - "bug\/.*"
+    - "\.*/bug\/.*"
 
 "chore":
   - head-branch:
-    - "chore/*"
-    - "*/chore/*"
+    - "chore\/.*"
+    - ".*\/chore\/.*"

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/navigate/NavigateEntryScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/navigate/NavigateEntryScreen.kt
@@ -234,7 +234,8 @@ class NavigateEntryScreen(
             is NavigationEntryState.Search -> SearchState(viewModel)
         }
 
-        SinatraBackHandler(true) {
+        val showBackButton by viewModel.showBackButton.collectAsStateWithLifecycle()
+        SinatraBackHandler(showBackButton) {
             if (viewModel.back()) {
                 navigator.pop()
             }


### PR DESCRIPTION
When navigating to NavigateEntryScreen through the bottom tab, a back gesture should exit the app entirely. However, it did nothing. This PR resolves that.
