### PR TITLE
Mark StopVisibility as Serializable

### DIFF
--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Stop.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Stop.kt
@@ -48,7 +48,7 @@ data class StopVisibility(
     val visibleZoomedIn: Boolean,
     val showChildren: Boolean,
     val searchWeight: Double?
-) {
+): Serializable {
 
     companion object {
         const val SHOW_CHILDREN_DEFAULT = false


### PR DESCRIPTION
Resolves Crashlytics exception with stacktrace:

```
Parcelable encountered IOException writing serializable object (name = cl.emilym.sinatra.ui.presentation.screens.maps.navigate.NavigateEntryScreen)
...
Caused by java.io.NotSerializableException: cl.emilym.sinatra.data.models.StopVisibility
       at java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1240)
       at java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1620)
       at java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1581)
       at java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1490)
```
