### PR TITLE
Hide maps from accessibility

### DIFF
--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
@@ -32,5 +32,5 @@ object FeatureFlags {
     val NAVIGATE_BUTTON_TAB_BAR by FeatureFlagDelegate(true)
     val PLACE_DETAIL_ENABLED by FeatureFlagDelegate(true)
     val SPECIFY_TIMEZONE_WHEN_DIFFERENT by FeatureFlagDelegate(true)
-    val HIDE_MAPS_FROM_ACCESSIBILITY by FeatureFlagDelegate(true)
+    val HIDE_MAPS_FROM_ACCESSIBILITY by FeatureFlagDelegate(false)
 }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
@@ -32,4 +32,5 @@ object FeatureFlags {
     val NAVIGATE_BUTTON_TAB_BAR by FeatureFlagDelegate(true)
     val PLACE_DETAIL_ENABLED by FeatureFlagDelegate(true)
     val SPECIFY_TIMEZONE_WHEN_DIFFERENT by FeatureFlagDelegate(true)
+    val HIDE_MAPS_FROM_ACCESSIBILITY by FeatureFlagDelegate(true)
 }

--- a/ui/src/androidMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/RootMapScreen.android.kt
+++ b/ui/src/androidMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/RootMapScreen.android.kt
@@ -1,5 +1,6 @@
 package cl.emilym.sinatra.ui.presentation.screens
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -44,7 +45,10 @@ import com.google.maps.android.compose.rememberCameraPositionState
 import com.google.maps.android.compose.rememberMarkerState
 
 @Composable
-actual fun Map(mapControl: MapControl) {
+actual fun Map(
+    mapControl: MapControl,
+    modifier: Modifier
+) {
     val context = LocalContext.current
 
     val cameraPositionState = rememberCameraPositionState {
@@ -76,37 +80,39 @@ actual fun Map(mapControl: MapControl) {
         (mapControl as? SafeMapControl)?.wrapped = realMapControl
     }
 
-    GoogleMap(
-        modifier = Modifier.fillMaxSize(),
-        cameraPositionState = cameraPositionState,
-        googleMapOptionsFactory = {
-            GoogleMapOptions()
-        },
-        properties = MapProperties(
-            mapStyleOptions = MapStyleOptions.loadRawResourceStyle(context, R.raw.maps_style)
-        ),
-        uiSettings = MapUiSettings(
-            compassEnabled = false,
-            rotationGesturesEnabled = false,
-            myLocationButtonEnabled = false,
-            zoomControlsEnabled = false
-        ),
-        contentPadding = insets,
-        mapColorScheme = ComposeMapColorScheme.FOLLOW_SYSTEM
-    ) {
-        currentLocation?.let { DrawMarker(MarkerItem(it, currentLocationIcon)) }
+    Box(Modifier.then(modifier)) {
+        GoogleMap(
+            modifier = Modifier.fillMaxSize(),
+            cameraPositionState = cameraPositionState,
+            googleMapOptionsFactory = {
+                GoogleMapOptions()
+            },
+            properties = MapProperties(
+                mapStyleOptions = MapStyleOptions.loadRawResourceStyle(context, R.raw.maps_style)
+            ),
+            uiSettings = MapUiSettings(
+                compassEnabled = false,
+                rotationGesturesEnabled = false,
+                myLocationButtonEnabled = false,
+                zoomControlsEnabled = false
+            ),
+            contentPadding = insets,
+            mapColorScheme = ComposeMapColorScheme.FOLLOW_SYSTEM
+        ) {
+            currentLocation?.let { DrawMarker(MarkerItem(it, currentLocationIcon)) }
 
-        currentMapItems { items ->
-            for (item in items) {
-                when (item) {
-                    is MarkerItem -> DrawMarker(item)
-                    is LineItem -> DrawLine(item)
-                    else -> {}
+            currentMapItems { items ->
+                for (item in items) {
+                    when (item) {
+                        is MarkerItem -> DrawMarker(item)
+                        is LineItem -> DrawLine(item)
+                        else -> {}
+                    }
                 }
             }
-        }
 
-        nativeMapScope.currentDrawNativeMap()
+            nativeMapScope.currentDrawNativeMap()
+        }
     }
 }
 

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/RootMapScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/RootMapScreen.kt
@@ -38,7 +38,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.invisibleToUser
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.min
@@ -81,7 +85,21 @@ import sinatra.ui.generated.resources.navigation_bar_map
 import sinatra.ui.generated.resources.navigation_bar_navigate
 
 @Composable
-expect fun Map(mapControl: MapControl)
+expect fun Map(
+    mapControl: MapControl,
+    modifier: Modifier = Modifier
+)
+
+@OptIn(ExperimentalComposeUiApi::class)
+val mapModifier get() = Modifier
+    .fillMaxSize()
+    .then(
+        if (FeatureFlags.HIDE_MAPS_FROM_ACCESSIBILITY)
+            Modifier.clearAndSetSemantics {
+                invisibleToUser()
+            }
+        else Modifier
+    )
 
 class RootMapScreen: Screen {
 
@@ -110,7 +128,10 @@ class RootMapScreen: Screen {
                                 WindowWidthSizeClass.COMPACT -> {
                                     BottomSheet(scaffoldState) {
                                         ViewportSizeWidget {
-                                            Map(mapControl)
+                                            Map(
+                                                mapControl,
+                                                mapModifier
+                                            )
                                             MapOverlay()
                                         }
                                     }
@@ -134,7 +155,10 @@ class RootMapScreen: Screen {
                                             }
                                         }
                                         ViewportSizeWidget {
-                                            Map(mapControl)
+                                            Map(
+                                                mapControl,
+                                                mapModifier
+                                            )
                                             MapOverlay()
                                         }
                                     }

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/MapSearchScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/MapSearchScreen.kt
@@ -12,8 +12,11 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.invisibleToUser
 import androidx.compose.ui.semantics.semantics
 import cafe.adriel.voyager.core.screen.ScreenKey
 import cafe.adriel.voyager.koin.koinScreenModel
@@ -21,6 +24,7 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import cl.emilym.compose.requeststate.RequestState
 import cl.emilym.compose.units.rdp
+import cl.emilym.sinatra.FeatureFlags
 import cl.emilym.sinatra.data.models.Stop
 import cl.emilym.sinatra.ui.maps.MapItem
 import cl.emilym.sinatra.ui.maps.MarkerItem
@@ -51,6 +55,7 @@ class MapSearchScreen: MapScreen, NativeMapScreen {
     override val bottomSheetHalfHeight: Float
         get() = 0.25f
 
+    @OptIn(ExperimentalComposeUiApi::class)
     @Composable
     override fun Content() {
         val viewModel = koinScreenModel<MapSearchViewModel>()
@@ -87,9 +92,14 @@ class MapSearchScreen: MapScreen, NativeMapScreen {
                             onClick = {
                                 mapControl.moveToPoint(it, currentLocationZoom)
                             },
-                            Modifier.semantics {
-                                contentDescription = zoomContentDescription
-                            }
+                            Modifier.then(
+                                if (FeatureFlags.HIDE_MAPS_FROM_ACCESSIBILITY)
+                                    Modifier.clearAndSetSemantics { invisibleToUser() }
+                                else
+                                    Modifier.semantics {
+                                        contentDescription = zoomContentDescription
+                                    }
+                            )
                         ) { MyLocationIcon() }
                     }
                 }

--- a/ui/src/iosMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/RootMapScreen.ios.kt
+++ b/ui/src/iosMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/RootMapScreen.ios.kt
@@ -1,5 +1,6 @@
 package cl.emilym.sinatra.ui.presentation.screens
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -40,7 +41,10 @@ val globalPointOfInterestFilter = MKPointOfInterestFilter(excludingCategories = 
 
 @OptIn(ExperimentalComposeUiApi::class, ExperimentalForeignApi::class)
 @Composable
-actual fun Map(mapControl: MapControl) {
+actual fun Map(
+    mapControl: MapControl,
+    modifier: Modifier
+) {
 
     val state = rememberMapKitState {}
 
@@ -101,23 +105,25 @@ actual fun Map(mapControl: MapControl) {
 
     val coroutineScope = rememberCoroutineScope()
 
-    UIKitView(
-        modifier = Modifier.fillMaxSize(),
-        factory = {
-            MKMapView().apply {
-                setZoomEnabled(true)
-                setScrollEnabled(true)
-                setRotateEnabled(false)
-                setPointOfInterestFilter(globalPointOfInterestFilter)
-            }.also {
-                coroutineScope.launch { state.setMap(it) }
-            }
-        },
-        onRelease = {
-            coroutineScope.launch { state.setMap(null) }
-        },
-        properties = UIKitInteropProperties(
-            interactionMode = UIKitInteropInteractionMode.NonCooperative
+    Box(Modifier.then(modifier)) {
+        UIKitView(
+            modifier = Modifier.fillMaxSize(),
+            factory = {
+                MKMapView().apply {
+                    setZoomEnabled(true)
+                    setScrollEnabled(true)
+                    setRotateEnabled(false)
+                    setPointOfInterestFilter(globalPointOfInterestFilter)
+                }.also {
+                    coroutineScope.launch { state.setMap(it) }
+                }
+            },
+            onRelease = {
+                coroutineScope.launch { state.setMap(null) }
+            },
+            properties = UIKitInteropProperties(
+                interactionMode = UIKitInteropInteractionMode.NonCooperative
+            )
         )
-    )
+    }
 }


### PR DESCRIPTION
Should hopefully make the app easier to understand for people using screen readers by presenting a more linear experience.

Disabled by default