### PR TITLE
Add a minimum version barrier

### DIFF
--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/IsAboveMinimumVersionUseCaseTest.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/IsAboveMinimumVersionUseCaseTest.kt
@@ -1,0 +1,139 @@
+package cl.emilym.sinatra.domain
+
+import cl.emilym.sinatra.BuildInformation
+import cl.emilym.sinatra.data.models.Cachable
+import cl.emilym.sinatra.data.models.CacheState
+import cl.emilym.sinatra.data.models.Service
+import cl.emilym.sinatra.data.repository.RemoteConfigRepository
+import cl.emilym.sinatra.data.repository.ServiceRepository
+import cl.emilym.sinatra.data.repository.TransportMetadataRepository
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class IsAboveMinimumVersionUseCaseTest {
+
+    private val remoteConfigRepository = mockk<RemoteConfigRepository>()
+    private val buildInformation = mockk<BuildInformation>()
+    private val useCase = IsAboveMinimumVersionUseCase(remoteConfigRepository, buildInformation)
+
+    @Test
+    fun `should return true when minimum version null`() = runTest {
+        // Arrange
+        coEvery { remoteConfigRepository.minimumVersion() } returns null
+
+        // Act
+        val result = useCase.invoke()
+
+        // Assert
+        assertTrue(result)
+    }
+
+    @Test
+    fun `should return true when minimum version throws exception`() = runTest {
+        // Arrange
+        coEvery { remoteConfigRepository.minimumVersion() } throws Exception()
+
+        // Act
+        val result = useCase.invoke()
+
+        // Assert
+        assertTrue(result)
+    }
+
+    @Test
+    fun `should return true when current major version greater than minimum major version`() = runTest {
+        // Arrange
+        coEvery { remoteConfigRepository.minimumVersion() } returns "1.0.0"
+        every { buildInformation.versionName } returns "2.0.0"
+
+        // Act
+        val result = useCase.invoke()
+
+        // Assert
+        assertTrue(result)
+    }
+
+    @Test
+    fun `should return true when current major version equals minimum major version`() = runTest {
+        // Arrange
+        coEvery { remoteConfigRepository.minimumVersion() } returns "1.0.0"
+        every { buildInformation.versionName } returns "1.0.0"
+
+        // Act
+        val result = useCase.invoke()
+
+        // Assert
+        assertTrue(result)
+    }
+
+    @Test
+    fun `should return false when current major version less than minimum major version`() = runTest {
+        // Arrange
+        coEvery { remoteConfigRepository.minimumVersion() } returns "1.0.0"
+        every { buildInformation.versionName } returns "0.0.0"
+
+        // Act
+        val result = useCase.invoke()
+
+        // Assert
+        assertFalse(result)
+    }
+
+    @Test
+    fun `should return true when current minor version greater than minimum minor version`() = runTest {
+        // Arrange
+        coEvery { remoteConfigRepository.minimumVersion() } returns "1.0.0"
+        every { buildInformation.versionName } returns "1.1.0"
+
+        // Act
+        val result = useCase.invoke()
+
+        // Assert
+        assertTrue(result)
+    }
+
+    @Test
+    fun `should return false when current minor version greater than minimum minor version`() = runTest {
+        // Arrange
+        coEvery { remoteConfigRepository.minimumVersion() } returns "1.1.0"
+        every { buildInformation.versionName } returns "1.0.0"
+
+        // Act
+        val result = useCase.invoke()
+
+        // Assert
+        assertFalse(result)
+    }
+
+    @Test
+    fun `should return false when minor versions match but majors are lower`() = runTest {
+        // Arrange
+        coEvery { remoteConfigRepository.minimumVersion() } returns "1.1.0"
+        every { buildInformation.versionName } returns "0.1.0"
+
+        // Act
+        val result = useCase.invoke()
+
+        // Assert
+        assertFalse(result)
+    }
+
+    @Test
+    fun `should successfully parse version with alpha`() = runTest {
+        // Act
+        val result = with(useCase) { "1.0.0-alpha.0".parse }
+
+        // Assert
+        assertEquals(result, listOf(1,0,0))
+    }
+
+}

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Aliases.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Aliases.kt
@@ -14,6 +14,7 @@ typealias Latitude = Double
 typealias Longitude = Double
 typealias Zoom = Float
 typealias Kilometer = Double
+typealias VersionName = String
 
 typealias Pixel = Float
 typealias DensityPixel = Float

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/RemoteConfigRepository.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/RemoteConfigRepository.kt
@@ -1,6 +1,7 @@
 package cl.emilym.sinatra.data.repository
 
 import cl.emilym.sinatra.data.client.RemoteConfigClient
+import cl.emilym.sinatra.data.models.VersionName
 import cl.emilym.sinatra.e
 import io.github.aakira.napier.Napier
 import org.koin.core.annotation.Factory
@@ -16,6 +17,7 @@ class RemoteConfigRepository(
         const val NOMINATIM_EMAIL_KEY = "nominatim_email"
         const val NOMINATIM_USER_AGENT_KEY = "nominatim_user_agent"
         const val CONTENT_URL_KEY = "content_url"
+        const val MINIMUM_VERSION_KEY = "minimum_version"
         const val FEATURE_FLAG_PREFIX = "feature_"
     }
 
@@ -41,6 +43,10 @@ class RemoteConfigRepository(
 
     suspend fun contentUrl(): String? {
         return remoteConfigClient.string(CONTENT_URL_KEY)
+    }
+
+    suspend fun minimumVersion(): VersionName? {
+        return remoteConfigClient.string(MINIMUM_VERSION_KEY)
     }
 
     suspend fun feature(name: String, default: Boolean = true): Boolean {

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/IsAboveMinimumVersionUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/IsAboveMinimumVersionUseCase.kt
@@ -1,0 +1,36 @@
+package cl.emilym.sinatra.domain
+
+import cl.emilym.sinatra.BuildInformation
+import cl.emilym.sinatra.data.models.VersionName
+import cl.emilym.sinatra.data.repository.RemoteConfigRepository
+import cl.emilym.sinatra.e
+import io.github.aakira.napier.Napier
+import org.koin.core.annotation.Factory
+
+@Factory
+class IsAboveMinimumVersionUseCase(
+    private val remoteConfigRepository: RemoteConfigRepository,
+    private val buildInformation: BuildInformation
+) {
+
+    suspend fun invoke(): Boolean {
+        val minimumVersion = try {
+            remoteConfigRepository.minimumVersion()?.parse ?: return true
+        } catch(e: Exception) {
+            Napier.e(e)
+            return true
+        }
+        val currentVersion = buildInformation.versionName.parse
+
+        for (i in 0..2) {
+            if (currentVersion[i] < minimumVersion[i]) return false
+        }
+        return true
+    }
+
+    val VersionName.parse: List<Int> get() =
+        split(".")
+            .take(3)
+            .map { it.takeWhile { it.isDigit() }.toInt() }
+
+}

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/IsAboveMinimumVersionUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/IsAboveMinimumVersionUseCase.kt
@@ -20,7 +20,12 @@ class IsAboveMinimumVersionUseCase(
             Napier.e(e)
             return true
         }
-        val currentVersion = buildInformation.versionName.parse
+        val currentVersion = try {
+            buildInformation.versionName.parse
+        } catch(e: Exception) {
+            Napier.e(e)
+            return true
+        }
 
         for (i in 0..2) {
             if (currentVersion[i] < minimumVersion[i]) return false

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/IsAboveMinimumVersionUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/IsAboveMinimumVersionUseCase.kt
@@ -13,7 +13,7 @@ class IsAboveMinimumVersionUseCase(
     private val buildInformation: BuildInformation
 ) {
 
-    suspend fun invoke(): Boolean {
+    suspend operator fun invoke(): Boolean {
         val minimumVersion = try {
             remoteConfigRepository.minimumVersion()?.parse ?: return true
         } catch(e: Exception) {

--- a/ui/src/androidMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/AppOutOfDateScreen.android.kt
+++ b/ui/src/androidMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/AppOutOfDateScreen.android.kt
@@ -1,0 +1,12 @@
+package cl.emilym.sinatra.ui.presentation.screens
+
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+import sinatra.ui.generated.resources.Res
+import sinatra.ui.generated.resources.app_out_of_date_android_link
+import sinatra.ui.generated.resources.app_out_of_date_android_title
+
+internal actual val Res.string.app_out_of_date_store_title: StringResource
+    get() = Res.string.app_out_of_date_android_title
+internal actual val Res.string.app_out_of_date_store_link: StringResource
+    get() = Res.string.app_out_of_date_android_link

--- a/ui/src/commonMain/composeResources/values/strings.xml
+++ b/ui/src/commonMain/composeResources/values/strings.xml
@@ -136,6 +136,15 @@
     <string name="navigate_entry_no_destination">Pick a destination to plan a journey.</string>
     <string name="navigate_entry_no_starting_point_destination">Pick a starting point and destination to plan a journey.</string>
 
+    <string name="app_out_of_date_title">Sinatra needs to be updated</string>
+    <string name="app_out_of_date_content">Sinatra is currently out of date and requires an update to function properly. Please update it to the latest version to restore compatibility and ensure reliable performance.</string>
+    <string name="app_out_of_date_android_title">Sinatra on Google Play</string>
+    <string name="app_out_of_date_android_link">https://play.google.com/store/apps/details?id=cl.emilym.sinatra</string>
+    <string name="app_out_of_date_ios_title">Sinatra on the App Store</string>
+    <string name="app_out_of_date_ios_link">https://apps.apple.com/us/app/sinatra-for-canberra/id6739419456</string>
+    <string name="app_out_of_date_homepage_title">Visit our website</string>
+    <string name="app_out_of_date_homepage_link">https://sinatra-transport.com</string>
+
     <string name="time_am">am</string>
     <string name="time_pm">pm</string>
     <string name="day_of_week_monday">Monday</string>

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/App.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/App.kt
@@ -16,7 +16,9 @@ import cl.emilym.sinatra.data.repository.LocaleRepository
 import cl.emilym.sinatra.data.repository.RemoteConfigRepository
 import cl.emilym.sinatra.data.repository.TransportMetadataRepository
 import cl.emilym.sinatra.domain.CacheInvalidationUseCase
+import cl.emilym.sinatra.domain.IsAboveMinimumVersionUseCase
 import cl.emilym.sinatra.ui.localization.LocalScheduleTimeZone
+import cl.emilym.sinatra.ui.presentation.screens.AppOutOfDateScreen
 import cl.emilym.sinatra.ui.presentation.screens.RootMapScreen
 import cl.emilym.sinatra.ui.presentation.theme.SinatraTheme
 import cl.emilym.sinatra.ui.widgets.LocalPermissionRequestQueue
@@ -30,6 +32,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
 import org.koin.compose.KoinContext
+import org.koin.core.KoinApplication.Companion.init
 import org.koin.core.annotation.Factory
 
 @Factory
@@ -37,10 +40,12 @@ class AppViewModel(
     private val transportMetadataRepository: TransportMetadataRepository,
     private val localeRepository: LocaleRepository,
     private val remoteConfigRepository: RemoteConfigRepository,
-    private val cacheInvalidationUseCase: CacheInvalidationUseCase
+    private val cacheInvalidationUseCase: CacheInvalidationUseCase,
+    private val isAboveMinimumVersionUseCase: IsAboveMinimumVersionUseCase
 ): ScreenModel {
 
     val scheduleTimeZone = MutableStateFlow(TimeZone.currentSystemDefault())
+    val aboveMinimumVersion = MutableStateFlow(true)
 
     init {
         screenModelScope.launch {
@@ -48,6 +53,7 @@ class AppViewModel(
         }
         screenModelScope.launch {
             remoteConfigRepository.load()
+            aboveMinimumVersion.value = isAboveMinimumVersionUseCase()
         }
         screenModelScope.launch {
             cacheInvalidationUseCase()
@@ -81,6 +87,7 @@ class AppScreen: Screen {
         val viewModel = koinScreenModel<AppViewModel>()
         val permissionQueue = remember { PermissionRequestQueue() }
         val timeZone by viewModel.scheduleTimeZone.collectAsStateWithLifecycle()
+        val isAboveMinimumVersion by viewModel.aboveMinimumVersion.collectAsStateWithLifecycle()
 
         val currentLocale = Locale.current
         LaunchedEffect(currentLocale) {
@@ -93,7 +100,10 @@ class AppScreen: Screen {
                 LocalPermissionRequestQueue provides permissionQueue
             ) {
                 PermissionRequestQueueHandler()
-                Navigator(RootMapScreen())
+                when {
+                    isAboveMinimumVersion -> Navigator(RootMapScreen())
+                    else -> AppOutOfDateScreen()
+                }
             }
         }
     }

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/AppOutOfDateScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/AppOutOfDateScreen.kt
@@ -1,0 +1,102 @@
+package cl.emilym.sinatra.ui.presentation.screens
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.core.screen.ScreenKey
+import cafe.adriel.voyager.koin.koinScreenModel
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import cl.emilym.compose.units.rdp
+import cl.emilym.sinatra.data.models.ContentLink
+import cl.emilym.sinatra.ui.widgets.ContentLinkWidget
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+import sinatra.ui.generated.resources.Res
+import sinatra.ui.generated.resources.app_out_of_date_content
+import sinatra.ui.generated.resources.app_out_of_date_homepage_link
+import sinatra.ui.generated.resources.app_out_of_date_homepage_title
+import sinatra.ui.generated.resources.app_out_of_date_title
+import sinatra.ui.generated.resources.in_app_icon
+import sinatra.ui.generated.resources.semantics_app_icon
+
+@Composable
+fun AppOutOfDateScreen() {
+    Scaffold { internalPadding ->
+        Column(
+            Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+        ) {
+            Column(
+                Modifier.padding(internalPadding).padding(vertical = 1.rdp),
+                verticalArrangement = Arrangement.spacedBy(1.rdp)
+            ) {
+                Column(
+                    Modifier.padding(horizontal = 1.rdp),
+                    verticalArrangement = Arrangement.spacedBy(1.rdp)
+                ) {
+                    Box(
+                        Modifier.fillMaxWidth(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Image(
+                            painterResource(Res.drawable.in_app_icon),
+                            contentDescription = stringResource(Res.string.semantics_app_icon),
+                            modifier = Modifier.padding(horizontal = 1.rdp).widthIn(max = 150.dp)
+                        )
+                    }
+                    Text(
+                        stringResource(Res.string.app_out_of_date_title),
+                        style = MaterialTheme.typography.titleLarge,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    Text(
+                        stringResource(Res.string.app_out_of_date_content)
+                    )
+                }
+
+                Column(
+                    Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(2.dp)
+                ) {
+                    ContentLinkWidget(
+                        ContentLink.external(
+                            stringResource(Res.string.app_out_of_date_store_title),
+                            stringResource(Res.string.app_out_of_date_store_link)
+                        )!!,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    ContentLinkWidget(
+                        ContentLink.external(
+                            stringResource(Res.string.app_out_of_date_homepage_title),
+                            stringResource(Res.string.app_out_of_date_homepage_link)
+                        )!!,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            }
+        }
+    }
+}
+
+internal expect val Res.string.app_out_of_date_store_title: StringResource
+internal expect val Res.string.app_out_of_date_store_link: StringResource

--- a/ui/src/nativeMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/AppOutOfDateScreen.native.kt
+++ b/ui/src/nativeMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/AppOutOfDateScreen.native.kt
@@ -1,0 +1,11 @@
+package cl.emilym.sinatra.ui.presentation.screens
+
+import org.jetbrains.compose.resources.StringResource
+import sinatra.ui.generated.resources.Res
+import sinatra.ui.generated.resources.app_out_of_date_ios_title
+import sinatra.ui.generated.resources.app_out_of_date_ios_link
+
+internal actual val Res.string.app_out_of_date_store_title: StringResource
+    get() = Res.string.app_out_of_date_ios_title
+internal actual val Res.string.app_out_of_date_store_link: StringResource
+    get() = Res.string.app_out_of_date_ios_link


### PR DESCRIPTION
Currently unused, but would allow extremely old versions of the app to be shut off.