### PR TITLE
Set json parser to lenient since Nominatim decided to change their API

### DIFF
--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/network/HttpMiddleware.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/network/HttpMiddleware.kt
@@ -57,6 +57,7 @@ fun ktorDependency(
     install(ContentNegotiation) {
         json(Json {
             ignoreUnknownKeys = true
+            isLenient = true
         })
     }
 }.apply {


### PR DESCRIPTION
Lat/lng is now a double, but I'm assuming could still be a string since there is no good documentation. Lenient lets it parse both :/
