### PR TITLE
Permit incomplete matches from nominatim API

### DIFF
--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/search/AbstractTypeSearcherTest.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/search/AbstractTypeSearcherTest.kt
@@ -1,13 +1,17 @@
 package cl.emilym.sinatra.domain.search
 
+import kotlin.jvm.java
 import kotlin.reflect.full.functions
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 class AbstractTypeSearcherTest {
 
-    private open class TestTypeSearcher : AbstractTypeSearcher<String>() {
+    private open class TestTypeSearcher(
+        override val permitIncompleteMatches: Boolean = false
+    ) : AbstractTypeSearcher<String>() {
         override fun fields(t: String): List<String> {
             return listOf(t)
         }
@@ -18,6 +22,7 @@ class AbstractTypeSearcherTest {
     }
 
     private val typeSearcher = TestTypeSearcher()
+    private val typeSearcherPermitIncomplete = TestTypeSearcher(true)
 
     @Test
     fun `match should return RankableResult when all tokens are matched`() {
@@ -45,6 +50,19 @@ class AbstractTypeSearcherTest {
         val result = matchMethod.invoke(typeSearcher, tokens, item) as RankableResult<String>?
 
         assertNull(result)
+    }
+
+    @Test
+    fun `match should return when not all tokens are matched and permitIncompleteMatches true`() {
+        val tokens = listOf("test", "example", "missing")
+        val item = "This is a test example"
+
+        val matchMethod = typeSearcherPermitIncomplete::class.java.superclass.declaredMethods.first { it.name == "match" }
+        matchMethod.isAccessible = true
+
+        val result = matchMethod.invoke(typeSearcherPermitIncomplete, tokens, item) as RankableResult<String>?
+
+        assertNotNull(result)
     }
 
     @Test

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/search/PlaceTypeSearcher.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/search/PlaceTypeSearcher.kt
@@ -15,6 +15,8 @@ class PlaceTypeSearcher(
 
     }
 
+    override val permitIncompleteMatches: Boolean = true
+
     override suspend fun invoke(tokens: List<String>): List<RankableResult<Place>> {
         if (tokens.sumOf { it.length } < MIN_QUERY_LENGTH) return listOf()
         if (!placeRepository.available()) return listOf()

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/search/RouteStopSearchUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/search/RouteStopSearchUseCase.kt
@@ -90,6 +90,8 @@ interface TypeSearcher<T> {
 
 abstract class AbstractTypeSearcher<T>: TypeSearcher<T> {
 
+    protected open val permitIncompleteMatches: Boolean = false
+
     protected abstract fun fields(t: T): List<String>
 
     open fun scoreMultiplier(item: T): Double { return 1.0 }
@@ -132,8 +134,8 @@ abstract class AbstractTypeSearcher<T>: TypeSearcher<T> {
         }
 
         return when {
-            matchedTokens.size != tokens.size -> null
-            highestScore == 0.0 -> null
+            matchedTokens.size != tokens.size && !permitIncompleteMatches -> null
+            highestScore == 0.0 && !permitIncompleteMatches -> null
             else -> RankableResult(item, scoreMultiplier(item) * highestScore)
         }
     }


### PR DESCRIPTION
Nominatim often returns a broader query if a house/apartment number is searched (i.e. London Circuit might be returned if 25 London Circuit was the query). This is the preferred behaviour since returning the street is better than nothing at all.