### PR TITLE
Add a feature flag to hide all transport accessibility information/options

### DIFF
--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/LastDepartureForStopUseCaseTest.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/LastDepartureForStopUseCaseTest.kt
@@ -54,7 +54,7 @@ class LastDepartureForStopUseCaseTest {
     fun setup() {
         every { clock.now() } returns baseTime
         coEvery { metadataRepository.timeZone() } returns testTimeZone
-        coEvery { remoteConfigRepository.feature(any()) } returns false
+        coEvery { remoteConfigRepository.feature(any<String>()) } returns false
     }
 
     @AfterTest

--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/prompt/FavouriteNearbyStopDeparturesUseCaseTest.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/prompt/FavouriteNearbyStopDeparturesUseCaseTest.kt
@@ -87,7 +87,7 @@ class FavouriteNearbyStopDeparturesUseCaseTest {
 
     @Test
     fun `should emit null if no favourite stop nearby`() = runTest {
-        coEvery { remoteConfigRepository.feature(any()) } returns true
+        coEvery { remoteConfigRepository.feature(any<String>()) } returns true
         coEvery { nearbyStopsUseCase(any(), any(), any()) } returns listOf(StopWithDistance(stop, 0.0))
         coEvery { favouriteRepository.favouritedStops(listOf(stop.id)) } returns flowOf(emptyList())
 
@@ -98,7 +98,7 @@ class FavouriteNearbyStopDeparturesUseCaseTest {
 
     @Test
     fun `should emit null if upcoming departures are empty`() = runTest {
-        coEvery { remoteConfigRepository.feature(any()) } returns true
+        coEvery { remoteConfigRepository.feature(any<String>()) } returns true
         coEvery { nearbyStopsUseCase(any(), any(), any()) } returns listOf(StopWithDistance(stop, 0.0))
         coEvery { favouriteRepository.favouritedStops(listOf(stop.id)) } returns flowOf(listOf(stop.id))
         coEvery { upcomingRoutesForStopUseCase(stop.id) } returns flowOf(Cachable(emptyList(), CacheState.LIVE))
@@ -110,7 +110,7 @@ class FavouriteNearbyStopDeparturesUseCaseTest {
 
     @Test
     fun `should emit StopDepartures if favourite nearby stop and upcoming departures exist`() = runTest {
-        coEvery { remoteConfigRepository.feature(any()) } returns true
+        coEvery { remoteConfigRepository.feature(any<String>()) } returns true
         coEvery { nearbyStopsUseCase(any(), any(), any()) } returns listOf(StopWithDistance(stop, 0.0))
         coEvery { favouriteRepository.favouritedStops(listOf(stop.id)) } returns flowOf(listOf(stop.id))
         coEvery { upcomingRoutesForStopUseCase(stop.id) } returns flowOf(cachableDepartures)
@@ -123,7 +123,7 @@ class FavouriteNearbyStopDeparturesUseCaseTest {
 
     @Test
     fun `should emit closest StopDepartures`() = runTest {
-        coEvery { remoteConfigRepository.feature(any()) } returns true
+        coEvery { remoteConfigRepository.feature(any<String>()) } returns true
         coEvery { nearbyStopsUseCase(any(), any(), any()) } returns listOf(
             StopWithDistance(stop, 0.0),
             StopWithDistance(stop2, 1.0),

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
@@ -17,12 +17,32 @@ private class FeatureFlagDelegate(
 
 }
 
+private class EnumFeatureFlagDelegate(
+    val flag: FeatureFlag
+) {
+    private val remoteConfigRepository by lazy { KoinPlatform.getKoin().get<RemoteConfigRepository>() }
+
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): Boolean {
+        return remoteConfigRepository.featureImmediate(flag)
+    }
+}
+
+enum class FeatureFlag(
+    val default: Boolean,
+    val overrideName: String? = null
+) {
+    GLOBAL_HIDE_TRANSPORT_ACCESSIBILITY(false),
+    STOP_DETAIL_SHOW_ACCESSIBILITY(true)
+}
+
+val FeatureFlag.flagName: String
+    get() = overrideName ?: this.name.lowercase()
+
 object FeatureFlags {
     val ROUTE_DETAIL_CLICKABLE_STOPS by FeatureFlagDelegate(true)
     val ROUTE_DETAIL_HIGHLIGHT_SOURCE_STOP by FeatureFlagDelegate(false)
     val ROUTE_DETAIL_PREVENT_ZOOM_WHEN_HAVE_SOURCE_STOP by FeatureFlagDelegate(false)
     val ROUTE_DETAIL_NEAREST_STOP by FeatureFlagDelegate(true)
-    val STOP_DETAIL_SHOW_ACCESSIBILITY by FeatureFlagDelegate(true)
     val STOP_DETAIL_SHOW_ROUTE_FILTER by FeatureFlagDelegate(true)
     val STOP_DETAIL_MANUALLY_ADJUST_PLATFORM_NAME by FeatureFlagDelegate(true)
     val STOP_DETAIL_HIDE_PLATFORM_FOR_SYNTHETIC by FeatureFlagDelegate(true)

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/client/RemoteConfigClient.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/client/RemoteConfigClient.kt
@@ -10,6 +10,9 @@ class RemoteConfigClient(
     private val wrapper: RemoteConfigWrapper
 ) {
 
+    val loaded: Boolean
+        get() = wrapper.loaded
+
     suspend fun load(): Boolean {
         return try {
             wrapper.load()

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/RemoteConfigRepository.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/RemoteConfigRepository.kt
@@ -23,6 +23,8 @@ class RemoteConfigRepository(
         const val FEATURE_FLAG_PREFIX = "feature_"
     }
 
+    val loaded: Boolean get() = remoteConfigClient.loaded
+
     suspend fun load() {
         remoteConfigClient.load()
     }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/RemoteConfigRepository.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/RemoteConfigRepository.kt
@@ -1,8 +1,10 @@
 package cl.emilym.sinatra.data.repository
 
+import cl.emilym.sinatra.FeatureFlag
 import cl.emilym.sinatra.data.client.RemoteConfigClient
 import cl.emilym.sinatra.data.models.VersionName
 import cl.emilym.sinatra.e
+import cl.emilym.sinatra.flagName
 import io.github.aakira.napier.Napier
 import org.koin.core.annotation.Factory
 
@@ -53,10 +55,12 @@ class RemoteConfigRepository(
         return remoteConfigClient.string(MINIMUM_VERSION_KEY)
     }
 
+    @Deprecated("Use FeatureFlag enum")
     suspend fun feature(name: String, default: Boolean = true): Boolean {
         return remoteConfigClient.boolean("$FEATURE_FLAG_PREFIX$name") ?: default
     }
 
+    @Deprecated("Use FeatureFlag enum")
     fun featureImmediate(name: String, default: Boolean = true): Boolean {
         return try {
             remoteConfigClient.booleanImmediate("$FEATURE_FLAG_PREFIX$name") ?: default
@@ -65,5 +69,9 @@ class RemoteConfigRepository(
             default
         }
     }
+
+    suspend fun feature(flag: FeatureFlag): Boolean = feature(flag.flagName, flag.default)
+
+    fun featureImmediate(flag: FeatureFlag): Boolean = featureImmediate(flag.flagName, flag.default)
 
 }

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/route/RouteDetailScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/route/RouteDetailScreen.kt
@@ -54,6 +54,7 @@ import cl.emilym.compose.requeststate.RequestStateWidget
 import cl.emilym.compose.requeststate.map
 import cl.emilym.compose.requeststate.unwrap
 import cl.emilym.compose.units.rdp
+import cl.emilym.sinatra.FeatureFlag
 import cl.emilym.sinatra.FeatureFlags
 import cl.emilym.sinatra.bounds
 import cl.emilym.sinatra.data.models.IRouteTripInformation
@@ -103,6 +104,7 @@ import cl.emilym.sinatra.ui.widgets.WheelchairAccessibleIcon
 import cl.emilym.sinatra.ui.widgets.collectAsStateWithLifecycle
 import cl.emilym.sinatra.ui.widgets.currentLocation
 import cl.emilym.sinatra.ui.widgets.pick
+import cl.emilym.sinatra.ui.widgets.value
 import com.mikepenz.markdown.m3.Markdown
 import io.github.aakira.napier.Napier
 import kotlinx.datetime.Instant
@@ -210,7 +212,10 @@ class RouteDetailScreen(
         val heading by viewModel.heading.collectAsStateWithLifecycle()
         val headings by viewModel.headings.collectAsStateWithLifecycle()
         val isToday by viewModel.isToday.collectAsStateWithLifecycle()
-        val showAccessibility by viewModel.showAccessibility.collectAsStateWithLifecycle()
+        val showAccessibility =
+            viewModel.showAccessibility.collectAsStateWithLifecycle().value &&
+            !FeatureFlag.GLOBAL_HIDE_TRANSPORT_ACCESSIBILITY.value()
+
 
         val current = if (trigger != null) {
             remember(trigger) {

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/stop/StopDetailScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/stop/StopDetailScreen.kt
@@ -48,6 +48,7 @@ import cl.emilym.compose.requeststate.RequestState
 import cl.emilym.compose.requeststate.RequestStateWidget
 import cl.emilym.compose.requeststate.unwrap
 import cl.emilym.compose.units.rdp
+import cl.emilym.sinatra.FeatureFlag
 import cl.emilym.sinatra.FeatureFlags
 import cl.emilym.sinatra.data.models.IStopTimetableTime
 import cl.emilym.sinatra.data.models.ReferencedTime
@@ -79,6 +80,7 @@ import cl.emilym.sinatra.ui.widgets.UpcomingRouteCard
 import cl.emilym.sinatra.ui.widgets.WheelchairAccessibleIcon
 import cl.emilym.sinatra.ui.widgets.collectAsStateWithLifecycle
 import cl.emilym.sinatra.ui.widgets.pick
+import cl.emilym.sinatra.ui.widgets.value
 import org.jetbrains.compose.resources.stringResource
 import sinatra.ui.generated.resources.Res
 import sinatra.ui.generated.resources.accessibility_not_wheelchair_accessible
@@ -158,7 +160,10 @@ class StopDetailScreen(
                                                 style = MaterialTheme.typography.titleLarge,
                                                 modifier = Modifier.weight(1f, fill = false)
                                             )
-                                            if (FeatureFlags.STOP_DETAIL_SHOW_ACCESSIBILITY) {
+                                            if (
+                                                !FeatureFlag.GLOBAL_HIDE_TRANSPORT_ACCESSIBILITY.value() &&
+                                                FeatureFlag.STOP_DETAIL_SHOW_ACCESSIBILITY.value()
+                                            ) {
                                                 WheelchairAccessibleIcon(
                                                     stop.accessibility.wheelchair.isAccessible,
                                                     contentDescription = when (stop.accessibility.wheelchair.isAccessible) {

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/preferences/RoutingPreferencesScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/preferences/RoutingPreferencesScreen.kt
@@ -10,12 +10,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.ScreenKey
+import cl.emilym.sinatra.FeatureFlag
 import cl.emilym.sinatra.lib.FloatRange
 import cl.emilym.sinatra.ui.text
 import cl.emilym.sinatra.ui.widgets.form.HorizontalLockup
 import cl.emilym.sinatra.ui.widgets.form.PreferencesCheckbox
 import cl.emilym.sinatra.ui.widgets.form.PreferencesFloatSlider
 import cl.emilym.sinatra.ui.widgets.form.VerticalLockup
+import cl.emilym.sinatra.ui.widgets.value
 import org.jetbrains.compose.resources.stringResource
 import sinatra.ui.generated.resources.Res
 import sinatra.ui.generated.resources.preferences_setting_bikes
@@ -36,28 +38,31 @@ class RoutingPreferencesScreen: PreferencesScreen() {
 
     @Composable
     override fun ColumnScope.Preferences(preferencesCollection: PreferencesCollection) {
-        HorizontalLockup(
-            stringResource(Res.string.preferences_setting_wheelchair),
-            stringResource(Res.string.preferences_setting_wheelchair_subtitle),
-            Modifier.fillMaxWidth()
-        ) {
-            PreferencesCheckbox(preferencesCollection.requiresWheelchair)
-        }
+        val showAccessibilitySettings = !FeatureFlag.GLOBAL_HIDE_TRANSPORT_ACCESSIBILITY.value()
+        if (showAccessibilitySettings) {
+            HorizontalLockup(
+                stringResource(Res.string.preferences_setting_wheelchair),
+                stringResource(Res.string.preferences_setting_wheelchair_subtitle),
+                Modifier.fillMaxWidth()
+            ) {
+                PreferencesCheckbox(preferencesCollection.requiresWheelchair)
+            }
 
-        HorizontalLockup(
-            stringResource(Res.string.preferences_setting_bikes),
-            stringResource(Res.string.preferences_setting_bikes_subtitle),
-            Modifier.fillMaxWidth()
-        ) {
-            PreferencesCheckbox(preferencesCollection.requiresBikes)
-        }
+            HorizontalLockup(
+                stringResource(Res.string.preferences_setting_bikes),
+                stringResource(Res.string.preferences_setting_bikes_subtitle),
+                Modifier.fillMaxWidth()
+            ) {
+                PreferencesCheckbox(preferencesCollection.requiresBikes)
+            }
 
-        HorizontalLockup(
-            stringResource(Res.string.preferences_setting_show_accessibility_icons_navigation),
-            stringResource(Res.string.preferences_setting_show_accessibility_icons_navigation_subtitle),
-            Modifier.fillMaxWidth()
-        ) {
-            PreferencesCheckbox(preferencesCollection.showAccessibilityIconsNavigation)
+            HorizontalLockup(
+                stringResource(Res.string.preferences_setting_show_accessibility_icons_navigation),
+                stringResource(Res.string.preferences_setting_show_accessibility_icons_navigation_subtitle),
+                Modifier.fillMaxWidth()
+            ) {
+                PreferencesCheckbox(preferencesCollection.showAccessibilityIconsNavigation)
+            }
         }
 
         VerticalLockup(

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/FeatureFlagValue.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/FeatureFlagValue.kt
@@ -15,12 +15,17 @@ import org.koin.compose.koinInject
 @Composable
 fun FeatureFlag.value(): Boolean {
     val remoteConfigRepository = koinInject<RemoteConfigRepository>()
-    if (remoteConfigRepository.loaded) return remoteConfigRepository.featureImmediate(this@value)
-    var value by remember { mutableStateOf(default) }
+    var value by remember(name) { mutableStateOf(when (remoteConfigRepository.loaded) {
+        true -> remoteConfigRepository.featureImmediate(this@value)
+        else -> default
+    }) }
 
     LaunchedEffect(name) {
         try {
-            value = remoteConfigRepository.feature(this@value)
+            value = when (remoteConfigRepository.loaded) {
+                true -> remoteConfigRepository.featureImmediate(this@value)
+                else -> remoteConfigRepository.feature(this@value)
+            }
         } catch(e: Exception) {
             Napier.e(e)
         }

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/FeatureFlagValue.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/FeatureFlagValue.kt
@@ -1,0 +1,29 @@
+package cl.emilym.sinatra.ui.widgets
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import cl.emilym.sinatra.FeatureFlag
+import cl.emilym.sinatra.data.repository.RemoteConfigRepository
+import cl.emilym.sinatra.e
+import io.github.aakira.napier.Napier
+import org.koin.compose.koinInject
+
+@Composable
+fun FeatureFlag.value(): Boolean {
+    var value by remember { mutableStateOf(default) }
+    val remoteConfigRepository = koinInject<RemoteConfigRepository>()
+
+    LaunchedEffect(name) {
+        try {
+            value = remoteConfigRepository.feature(this@value)
+        } catch(e: Exception) {
+            Napier.e(e)
+        }
+    }
+
+    return value
+}

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/FeatureFlagValue.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/FeatureFlagValue.kt
@@ -14,8 +14,9 @@ import org.koin.compose.koinInject
 
 @Composable
 fun FeatureFlag.value(): Boolean {
-    var value by remember { mutableStateOf(default) }
     val remoteConfigRepository = koinInject<RemoteConfigRepository>()
+    if (remoteConfigRepository.loaded) return remoteConfigRepository.featureImmediate(this@value)
+    var value by remember { mutableStateOf(default) }
 
     LaunchedEffect(name) {
         try {
@@ -23,6 +24,7 @@ fun FeatureFlag.value(): Boolean {
         } catch(e: Exception) {
             Napier.e(e)
         }
+
     }
 
     return value


### PR DESCRIPTION
This also slightly improves how feature flags are organised.

This change is necessary because Transport Canberra removed all accessibility information from their API for some reason, so display should be disabled until that changes
