### PR TITLE
Include vehicles arriving at the stop the next day near the end of the day

### DIFF
--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/UpcomingRoutesForStopUseCaseTest.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/UpcomingRoutesForStopUseCaseTest.kt
@@ -1,10 +1,12 @@
 package cl.emilym.sinatra.domain
 
+import cl.emilym.sinatra.FeatureFlag
 import cl.emilym.sinatra.data.models.Cachable
 import cl.emilym.sinatra.data.models.Service
 import cl.emilym.sinatra.data.models.StopTimetable
 import cl.emilym.sinatra.data.models.StopTimetableTime
 import cl.emilym.sinatra.data.models.Time
+import cl.emilym.sinatra.data.models.startOfDay
 import cl.emilym.sinatra.data.repository.RemoteConfigRepository
 import cl.emilym.sinatra.data.repository.ServiceRepository
 import cl.emilym.sinatra.data.repository.StopRepository
@@ -25,6 +27,7 @@ import kotlinx.datetime.TimeZone
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.days
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class UpcomingRoutesForStopUseCaseTest {
@@ -257,6 +260,353 @@ class UpcomingRoutesForStopUseCaseTest {
         coVerify { servicesAndTimesForStopUseCase.invoke(stopId) }
         coVerify { metadataRepository.timeZone() }
         coVerify(exactly = 0) { liveStopTimetableUseCase.invoke(any(), any()) }
+        verify { clock.now() }
+    }
+
+    @Test
+    fun `should include next day times when after 10pm and feature flag enabled`() = runTest {
+        val stopId = "stop-123"
+        val timeZone = TimeZone.UTC
+        // Set time to 10:30 PM
+        val currentTime = Instant.parse("2024-01-01T22:30:00Z")
+
+        val timetable = listOf(
+            // Next day time
+            StopTimetableTime(
+                childStopId = null,
+                routeId = "route-2",
+                routeCode = "R2",
+                serviceId = "service-1",
+                tripId = "trip-2",
+                arrivalTime = Time.parse("PT6H"), // 6 AM next day
+                departureTime = Time.parse("PT6H5M"),
+                heading = "South",
+                sequence = 1,
+                last = false,
+                route = null,
+                childStop = null
+            ),
+            // Current day time that has already passed
+            StopTimetableTime(
+                childStopId = null,
+                routeId = "route-1",
+                routeCode = "R1",
+                serviceId = "service-1",
+                tripId = "trip-1",
+                arrivalTime = Time.parse("PT20H"), // 8 PM - already passed
+                departureTime = Time.parse("PT20H5M"),
+                heading = "North",
+                sequence = 1,
+                last = false,
+                route = null,
+                childStop = null
+            ),
+        )
+
+        val services = listOf(service)
+
+        every { service.active(any(), any(), any()) } returns true
+        coEvery { metadataRepository.timeZone() } returns timeZone
+        coEvery { servicesAndTimesForStopUseCase.invoke(stopId) } returns Cachable.live(
+            ServicesAndTimes(
+                services = services,
+                times = timetable
+            )
+        )
+        coEvery { clock.now() } returns currentTime
+        coEvery { remoteConfigRepository.feature(FeatureFlag.UPCOMING_ROUTES_INCLUDE_NEXT_DAY) } returns true
+
+        val result = useCase(stopId, number = 10, live = false).take(1).first()
+
+        assertEquals(2, result.item.size)
+        assertEquals("R2", result.item.first().routeCode)
+        assertEquals("R1", result.item.last().routeCode)
+        assertEquals((currentTime + 1.days).startOfDay(timeZone), result.item.last().arrivalTime.instant.startOfDay(timeZone))
+
+        coVerify { servicesAndTimesForStopUseCase.invoke(stopId) }
+        coVerify { metadataRepository.timeZone() }
+        coVerify { remoteConfigRepository.feature(FeatureFlag.UPCOMING_ROUTES_INCLUDE_NEXT_DAY) }
+        verify { clock.now() }
+    }
+
+    @Test
+    fun `should not include next day times when after 10pm but feature flag disabled`() = runTest {
+        val stopId = "stop-123"
+        val timeZone = TimeZone.UTC
+        // Set time to 10:30 PM
+        val currentTime = Instant.parse("2024-01-01T22:30:00Z")
+
+        val timetable = listOf(
+            // Current day time that has already passed
+            StopTimetableTime(
+                childStopId = null,
+                routeId = "route-1",
+                routeCode = "R1",
+                serviceId = "service-1",
+                tripId = "trip-1",
+                arrivalTime = Time.parse("PT20H"), // 8 PM - already passed
+                departureTime = Time.parse("PT20H5M"),
+                heading = "North",
+                sequence = 1,
+                last = false,
+                route = null,
+                childStop = null
+            ),
+            // Next day time
+            StopTimetableTime(
+                childStopId = null,
+                routeId = "route-2",
+                routeCode = "R2",
+                serviceId = "service-1",
+                tripId = "trip-2",
+                arrivalTime = Time.parse("PT6H"), // 6 AM next day
+                departureTime = Time.parse("PT6H5M"),
+                heading = "South",
+                sequence = 1,
+                last = false,
+                route = null,
+                childStop = null
+            )
+        )
+
+        val services = listOf(service)
+
+        every { service.active(any(), any(), any()) } returns true
+        coEvery { metadataRepository.timeZone() } returns timeZone
+        coEvery { servicesAndTimesForStopUseCase.invoke(stopId) } returns Cachable.live(
+            ServicesAndTimes(
+                services = services,
+                times = timetable
+            )
+        )
+        coEvery { clock.now() } returns currentTime
+        coEvery { remoteConfigRepository.feature(FeatureFlag.UPCOMING_ROUTES_INCLUDE_NEXT_DAY) } returns false
+
+        val result = useCase(stopId, number = 10, live = false).take(1).first()
+
+        assertEquals(0, result.item.size)
+
+        coVerify { servicesAndTimesForStopUseCase.invoke(stopId) }
+        coVerify { metadataRepository.timeZone() }
+        coVerify { remoteConfigRepository.feature(FeatureFlag.UPCOMING_ROUTES_INCLUDE_NEXT_DAY) }
+        verify { clock.now() }
+    }
+
+    @Test
+    fun `should not include next day times when before 10pm even with feature flag enabled`() = runTest {
+        val stopId = "stop-123"
+        val timeZone = TimeZone.UTC
+        // Set time to 9:30 PM (before 10 PM)
+        val currentTime = Instant.parse("2024-01-01T21:30:00Z")
+
+        val timetable = listOf(
+            // Current day time that is upcoming
+            StopTimetableTime(
+                childStopId = null,
+                routeId = "route-1",
+                routeCode = "R1",
+                serviceId = "service-1",
+                tripId = "trip-1",
+                arrivalTime = Time.parse("PT23H"), // 11 PM - still upcoming
+                departureTime = Time.parse("PT23H5M"),
+                heading = "North",
+                sequence = 1,
+                last = false,
+                route = null,
+                childStop = null
+            ),
+            // Next day time
+            StopTimetableTime(
+                childStopId = null,
+                routeId = "route-2",
+                routeCode = "R2",
+                serviceId = "service-1",
+                tripId = "trip-2",
+                arrivalTime = Time.parse("PT6H"), // 6 AM next day
+                departureTime = Time.parse("PT6H5M"),
+                heading = "South",
+                sequence = 1,
+                last = false,
+                route = null,
+                childStop = null
+            )
+        )
+
+        val services = listOf(service)
+
+        every { service.active(any(), any(), any()) } returns true
+        coEvery { metadataRepository.timeZone() } returns timeZone
+        coEvery { servicesAndTimesForStopUseCase.invoke(stopId) } returns Cachable.live(
+            ServicesAndTimes(
+                services = services,
+                times = timetable
+            )
+        )
+        coEvery { clock.now() } returns currentTime
+        coEvery { remoteConfigRepository.feature(FeatureFlag.UPCOMING_ROUTES_INCLUDE_NEXT_DAY) } returns true
+
+        val result = useCase(stopId, number = 10, live = false).take(1).first()
+
+        // Should only return the current day time (11 PM)
+        assertEquals(1, result.item.size)
+        assertEquals("R1", result.item.first().routeCode)
+        assertEquals(currentTime.startOfDay(timeZone), result.item.first().arrivalTime.instant.startOfDay(timeZone))
+
+        coVerify { servicesAndTimesForStopUseCase.invoke(stopId) }
+        coVerify { metadataRepository.timeZone() }
+        verify { clock.now() }
+    }
+
+    @Test
+    fun `should include both current and next day times when after 10pm with feature flag enabled`() = runTest {
+        val stopId = "stop-123"
+        val timeZone = TimeZone.UTC
+        // Set time to 10:30 PM
+        val currentTime = Instant.parse("2024-01-01T22:30:00Z")
+
+        val timetable = listOf(
+            // Next day time
+            StopTimetableTime(
+                childStopId = null,
+                routeId = "route-2",
+                routeCode = "R2",
+                serviceId = "service-1",
+                tripId = "trip-2",
+                arrivalTime = Time.parse("PT6H"), // 6 AM next day
+                departureTime = Time.parse("PT6H5M"),
+                heading = "South",
+                sequence = 1,
+                last = false,
+                route = null,
+                childStop = null
+            ),
+            // Current day time that is still upcoming
+            StopTimetableTime(
+                childStopId = null,
+                routeId = "route-1",
+                routeCode = "R1",
+                serviceId = "service-1",
+                tripId = "trip-1",
+                arrivalTime = Time.parse("PT23H"), // 11 PM - still upcoming
+                departureTime = Time.parse("PT23H5M"),
+                heading = "North",
+                sequence = 1,
+                last = false,
+                route = null,
+                childStop = null
+            ),
+        )
+
+        val services = listOf(service)
+
+        every { service.active(any(), any(), any()) } returns true
+        coEvery { metadataRepository.timeZone() } returns timeZone
+        coEvery { servicesAndTimesForStopUseCase.invoke(stopId) } returns Cachable.live(
+            ServicesAndTimes(
+                services = services,
+                times = timetable
+            )
+        )
+        coEvery { clock.now() } returns currentTime
+        coEvery { remoteConfigRepository.feature(FeatureFlag.UPCOMING_ROUTES_INCLUDE_NEXT_DAY) } returns true
+
+        val result = useCase(stopId, number = 10, live = false).take(1).first()
+
+        // Should return both times, sorted by arrival time
+        assertEquals(3, result.item.size)
+        assertEquals("R1", result.item.first().routeCode) // 11 PM today
+        assertEquals("R2", result.item[1].routeCode) // 6 AM tomorrow
+        assertEquals("R1", result.item.last().routeCode) // 11 PM tomorrow
+        assertEquals((currentTime).startOfDay(timeZone), result.item.first().arrivalTime.instant.startOfDay(timeZone))
+        assertEquals((currentTime + 1.days).startOfDay(timeZone), result.item[1].arrivalTime.instant.startOfDay(timeZone))
+        assertEquals((currentTime + 1.days).startOfDay(timeZone), result.item.last().arrivalTime.instant.startOfDay(timeZone))
+
+        coVerify { servicesAndTimesForStopUseCase.invoke(stopId) }
+        coVerify { metadataRepository.timeZone() }
+        coVerify { remoteConfigRepository.feature(FeatureFlag.UPCOMING_ROUTES_INCLUDE_NEXT_DAY) }
+        verify { clock.now() }
+    }
+
+    @Test
+    fun `should respect number limit when including next day times`() = runTest {
+        val stopId = "stop-123"
+        val timeZone = TimeZone.UTC
+        // Set time to 10:30 PM
+        val currentTime = Instant.parse("2024-01-01T22:30:00Z")
+
+        val timetable = listOf(
+            // Next day times
+            StopTimetableTime(
+                childStopId = null,
+                routeId = "route-2",
+                routeCode = "R2",
+                serviceId = "service-1",
+                tripId = "trip-2",
+                arrivalTime = Time.parse("PT6H"), // 6 AM next day
+                departureTime = Time.parse("PT6H5M"),
+                heading = "South",
+                sequence = 1,
+                last = false,
+                route = null,
+                childStop = null
+            ),
+            StopTimetableTime(
+                childStopId = null,
+                routeId = "route-3",
+                routeCode = "R3",
+                serviceId = "service-1",
+                tripId = "trip-3",
+                arrivalTime = Time.parse("PT7H"), // 7 AM next day
+                departureTime = Time.parse("PT7H5M"),
+                heading = "East",
+                sequence = 1,
+                last = false,
+                route = null,
+                childStop = null
+            ),
+            // Current day time
+            StopTimetableTime(
+                childStopId = null,
+                routeId = "route-1",
+                routeCode = "R1",
+                serviceId = "service-1",
+                tripId = "trip-1",
+                arrivalTime = Time.parse("PT23H"), // 11 PM - still upcoming
+                departureTime = Time.parse("PT23H5M"),
+                heading = "North",
+                sequence = 1,
+                last = false,
+                route = null,
+                childStop = null
+            ),
+        )
+
+        val services = listOf(service)
+
+        every { service.active(any(), any(), any()) } returns true
+        coEvery { metadataRepository.timeZone() } returns timeZone
+        coEvery { servicesAndTimesForStopUseCase.invoke(stopId) } returns Cachable.live(
+            ServicesAndTimes(
+                services = services,
+                times = timetable
+            )
+        )
+        coEvery { clock.now() } returns currentTime
+        coEvery { remoteConfigRepository.feature(FeatureFlag.UPCOMING_ROUTES_INCLUDE_NEXT_DAY) } returns true
+
+        val result = useCase(stopId, number = 2, live = false).take(1).first()
+
+        println("${result.item}")
+
+        // Should return only 2 times due to number limit
+        assertEquals(2, result.item.size)
+        assertEquals("R1", result.item.first().routeCode) // 11 PM today
+        assertEquals("R2", result.item.last().routeCode) // 6 AM tomorrow (R3 excluded due to limit)
+        assertEquals((currentTime + 1.days).startOfDay(timeZone), result.item.last().arrivalTime.instant.startOfDay(timeZone))
+
+        coVerify { servicesAndTimesForStopUseCase.invoke(stopId) }
+        coVerify { metadataRepository.timeZone() }
+        coVerify { remoteConfigRepository.feature(FeatureFlag.UPCOMING_ROUTES_INCLUDE_NEXT_DAY) }
         verify { clock.now() }
     }
 }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
@@ -44,7 +44,8 @@ enum class FeatureFlag(
     SPECIFY_TIMEZONE_WHEN_DIFFERENT(true),
     HIDE_MAPS_FROM_ACCESSIBILITY(false),
     HOLD_MAP_POINT_DETAIL(true),
-    GLOBAL_HIDE_TRANSPORT_ACCESSIBILITY(false);
+    GLOBAL_HIDE_TRANSPORT_ACCESSIBILITY(false),
+    UPCOMING_ROUTES_INCLUDE_NEXT_DAY(true);
 
     val immediate by EnumFeatureFlagDelegate(this)
 }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/UpcomingRoutesForStopUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/UpcomingRoutesForStopUseCase.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.isActive
 import kotlinx.datetime.Clock
+import kotlinx.datetime.toLocalDateTime
 import org.koin.core.annotation.Factory
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.minutes
@@ -57,7 +58,15 @@ class UpcomingRoutesForStopUseCase(
 
             while (currentCoroutineContext().isActive) {
                 val now = clock.now()
-                val checkTimes = listOf(now - 1.days, now)
+                val checkTimes = listOfNotNull(
+                    now - 1.days,
+                    now,
+                    // If it is after 10pm (and the feature flag is enabled) search next day
+                    if(
+                        now.toLocalDateTime(scheduleTimeZone).hour >= 22 &&
+                        remoteConfigRepository.feature(FeatureFlag.UPCOMING_ROUTES_INCLUDE_NEXT_DAY)
+                    ) now + 1.days else null
+                )
 
                 val active = mutableListOf<StopTimetableTime>()
 


### PR DESCRIPTION
After 10pm, begin to show upcoming vehicles from the next schedule day. This improves ergonomics in two ways:
1. On days where service continues until 1am (or something) without interruption, the previous arrangement misleadingly showed no upcoming vehicles in the next day *until* midnight had passed.
2. For other circumstances, it just makes it easier for someone at the end of the day to see upcoming vehicles the next day
