### PR TITLE
Adds school service filtering to routes and stops

### DIFF
--- a/shared/schemas/cl.emilym.sinatra.room.AppDatabase/10.json
+++ b/shared/schemas/cl.emilym.sinatra.room.AppDatabase/10.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 10,
-    "identityHash": "1d8bd16987da4d1e87eaf49f8372b439",
+    "identityHash": "8a3e7105930ac254c9d95fec32465844",
     "entities": [
       {
         "tableName": "ShaEntity",
@@ -48,7 +48,7 @@
       },
       {
         "tableName": "StopEntity",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `parentStation` TEXT, `name` TEXT NOT NULL, `simpleName` TEXT, `lat` REAL NOT NULL, `lng` REAL NOT NULL, `wheelchairAccessible` TEXT NOT NULL, `visibleZoomedOut` INTEGER DEFAULT NULL, `visibleZoomedIn` INTEGER DEFAULT NULL, `showChildren` INTEGER NOT NULL DEFAULT 0, `searchWeight` REAL DEFAULT NULL, `hasRealtime` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `parentStation` TEXT, `name` TEXT NOT NULL, `simpleName` TEXT, `lat` REAL NOT NULL, `lng` REAL NOT NULL, `wheelchairAccessible` TEXT NOT NULL, `visibleZoomedOut` INTEGER DEFAULT NULL, `visibleZoomedIn` INTEGER DEFAULT NULL, `showChildren` INTEGER NOT NULL DEFAULT 0, `searchWeight` REAL DEFAULT NULL, `hasRealtime` INTEGER NOT NULL DEFAULT 0, `schoolServiceOnly` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -118,6 +118,13 @@
           {
             "fieldPath": "hasRealtime",
             "columnName": "hasRealtime",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "schoolServiceOnly",
+            "columnName": "schoolServiceOnly",
             "affinity": "INTEGER",
             "notNull": true,
             "defaultValue": "0"
@@ -899,7 +906,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1d8bd16987da4d1e87eaf49f8372b439')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '8a3e7105930ac254c9d95fec32465844')"
     ]
   }
 }

--- a/shared/schemas/cl.emilym.sinatra.room.AppDatabase/10.json
+++ b/shared/schemas/cl.emilym.sinatra.room.AppDatabase/10.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 10,
-    "identityHash": "700eafebe4af5e7f4dabc47adb958e5f",
+    "identityHash": "1d8bd16987da4d1e87eaf49f8372b439",
     "entities": [
       {
         "tableName": "ShaEntity",
@@ -216,7 +216,7 @@
       },
       {
         "tableName": "RouteEntity",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `code` TEXT NOT NULL, `displayCode` TEXT NOT NULL, `color` TEXT, `onColor` TEXT, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `approximateTimings` INTEGER NOT NULL DEFAULT 0, `type` TEXT NOT NULL, `designation` TEXT, `hidden` INTEGER NOT NULL DEFAULT 0, `searchWeight` REAL DEFAULT NULL, `showOnBrowse` INTEGER NOT NULL DEFAULT 0, `eventRoute` INTEGER NOT NULL DEFAULT 0, `moreLink` TEXT DEFAULT NULL, `hasRealtime` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `code` TEXT NOT NULL, `displayCode` TEXT NOT NULL, `color` TEXT, `onColor` TEXT, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `approximateTimings` INTEGER NOT NULL DEFAULT 0, `type` TEXT NOT NULL, `designation` TEXT, `hidden` INTEGER NOT NULL DEFAULT 0, `searchWeight` REAL DEFAULT NULL, `showOnBrowse` INTEGER NOT NULL DEFAULT 0, `eventRoute` INTEGER NOT NULL DEFAULT 0, `moreLink` TEXT DEFAULT NULL, `hasRealtime` INTEGER NOT NULL DEFAULT 0, `schoolService` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -312,6 +312,13 @@
           {
             "fieldPath": "hasRealtime",
             "columnName": "hasRealtime",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "schoolService",
+            "columnName": "schoolService",
             "affinity": "INTEGER",
             "notNull": true,
             "defaultValue": "0"
@@ -892,7 +899,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '700eafebe4af5e7f4dabc47adb958e5f')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1d8bd16987da4d1e87eaf49f8372b439')"
     ]
   }
 }

--- a/shared/schemas/cl.emilym.sinatra.room.AppDatabase/10.json
+++ b/shared/schemas/cl.emilym.sinatra.room.AppDatabase/10.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 10,
-    "identityHash": "8a3e7105930ac254c9d95fec32465844",
+    "identityHash": "dfc5e818e43a80c7622574618fb1fe4c",
     "entities": [
       {
         "tableName": "ShaEntity",
@@ -223,7 +223,7 @@
       },
       {
         "tableName": "RouteEntity",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `code` TEXT NOT NULL, `displayCode` TEXT NOT NULL, `color` TEXT, `onColor` TEXT, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `approximateTimings` INTEGER NOT NULL DEFAULT 0, `type` TEXT NOT NULL, `designation` TEXT, `hidden` INTEGER NOT NULL DEFAULT 0, `searchWeight` REAL DEFAULT NULL, `showOnBrowse` INTEGER NOT NULL DEFAULT 0, `eventRoute` INTEGER NOT NULL DEFAULT 0, `moreLink` TEXT DEFAULT NULL, `hasRealtime` INTEGER NOT NULL DEFAULT 0, `schoolService` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `code` TEXT NOT NULL, `displayCode` TEXT NOT NULL, `color` TEXT, `onColor` TEXT, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `approximateTimings` INTEGER NOT NULL DEFAULT 0, `type` TEXT NOT NULL, `designation` TEXT, `hidden` INTEGER NOT NULL DEFAULT 0, `searchWeight` REAL DEFAULT NULL, `showOnBrowse` INTEGER NOT NULL DEFAULT 0, `eventRoute` INTEGER NOT NULL DEFAULT 0, `moreLink` TEXT DEFAULT NULL, `hasRealtime` INTEGER NOT NULL DEFAULT 0, `schoolServiceOnly` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -324,8 +324,8 @@
             "defaultValue": "0"
           },
           {
-            "fieldPath": "schoolService",
-            "columnName": "schoolService",
+            "fieldPath": "schoolServiceOnly",
+            "columnName": "schoolServiceOnly",
             "affinity": "INTEGER",
             "notNull": true,
             "defaultValue": "0"
@@ -906,7 +906,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '8a3e7105930ac254c9d95fec32465844')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'dfc5e818e43a80c7622574618fb1fe4c')"
     ]
   }
 }

--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/Defaults.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/Defaults.kt
@@ -27,7 +27,8 @@ val DefaultRoute get() = Route(
         true
     ),
     false,
-    null
+    null,
+    false,
 )
 
 val DefaultTimetableServiceRegular get() = TimetableServiceRegular(

--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/Defaults.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/Defaults.kt
@@ -1,10 +1,15 @@
 package cl.emilym.sinatra
 
+import cl.emilym.sinatra.data.models.MapLocation
 import cl.emilym.sinatra.data.models.Route
 import cl.emilym.sinatra.data.models.RouteType
 import cl.emilym.sinatra.data.models.RouteVisibility
 import cl.emilym.sinatra.data.models.Service
+import cl.emilym.sinatra.data.models.Stop
+import cl.emilym.sinatra.data.models.StopAccessibility
 import cl.emilym.sinatra.data.models.StopTimetableTime
+import cl.emilym.sinatra.data.models.StopVisibility
+import cl.emilym.sinatra.data.models.StopWheelchairAccessibility
 import cl.emilym.sinatra.data.models.TimetableServiceRegular
 import cl.emilym.sinatra.data.models.toTime
 import kotlinx.datetime.Clock
@@ -62,4 +67,27 @@ val DefaultStopTimetableTime get() = StopTimetableTime(
     false,
     DefaultRoute,
     null,
+)
+
+val DefaultStopAccessibility = StopAccessibility(
+    wheelchair = StopWheelchairAccessibility.FULL
+)
+
+val DefaultStopVisibility = StopVisibility(
+    visibleZoomedOut = false,
+    visibleZoomedIn = true,
+    showChildren = false,
+    searchWeight = null
+)
+
+val DefaultStop get() = Stop(
+    id = "default-stop",
+    parentStation = null,
+    name = "Default Stop",
+    _simpleName = "Default Stop",
+    location = MapLocation(100.0, 100.0),
+    accessibility = DefaultStopAccessibility,
+    visibility = DefaultStopVisibility,
+    hasRealtime = true,
+    schoolServiceOnly = false
 )

--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/CurrentTripForRouteUseCaseTest.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/CurrentTripForRouteUseCaseTest.kt
@@ -67,7 +67,8 @@ class CurrentTripForRouteUseCaseTest {
             false
         ),
         false,
-        null
+        null,
+        false,
     )
     val tripInformation = RouteTripInformation(
         Time.parse("PT12H"),

--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/DisplayRoutesUseCaseTest.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/DisplayRoutesUseCaseTest.kt
@@ -5,9 +5,13 @@ import cl.emilym.sinatra.data.models.Route
 import cl.emilym.sinatra.data.models.RouteType
 import cl.emilym.sinatra.data.models.RouteVisibility
 import cl.emilym.sinatra.data.repository.RouteRepository
+import coil3.util.CoilUtils.result
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -15,26 +19,26 @@ import kotlin.test.assertFailsWith
 
 class DisplayRoutesUseCaseTest {
 
-    private val routeRepository = mockk<RouteRepository>()
-    private val displayRoutesUseCase = DisplayRoutesUseCase(routeRepository)
+    private val getFilteredRoutesUseCase = mockk<GetFilteredRoutesUseCase>()
+    private val displayRoutesUseCase = DisplayRoutesUseCase(getFilteredRoutesUseCase)
 
     @Test
     fun `should return empty list when routes are empty`() = runBlocking {
         // Arrange
-        coEvery { routeRepository.routes() } returns Cachable.live(emptyList())
+        coEvery { getFilteredRoutesUseCase() } returns flowOf(Cachable.live(emptyList()))
 
         // Act
-        val result = displayRoutesUseCase()
+        val result = displayRoutesUseCase().first()
 
         // Assert
         assertEquals(Cachable.live(emptyList<Route>()), result)
-        coVerify(exactly = 1) { routeRepository.routes() }
+        verify(exactly = 1) { getFilteredRoutesUseCase.invoke() }
     }
 
     @Test
     fun `should handle failure from routes call`() = runBlocking {
         // Arrange
-        coEvery { routeRepository.routes() } throws Exception("Failed to fetch routes")
+        coEvery { getFilteredRoutesUseCase() } throws Exception("Failed to fetch routes")
 
         // Act
         assertFailsWith<Exception>("Failed to fetch routes") {
@@ -42,6 +46,6 @@ class DisplayRoutesUseCaseTest {
         }
 
         // Assert
-        coVerify(exactly = 1) { routeRepository.routes() }
+        coVerify(exactly = 1) { getFilteredRoutesUseCase.invoke() }
     }
 }

--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/GetFilteredRoutesUseCaseTest.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/GetFilteredRoutesUseCaseTest.kt
@@ -1,0 +1,257 @@
+package cl.emilym.sinatra.domain
+
+import cl.emilym.sinatra.DefaultRoute
+import cl.emilym.sinatra.data.models.Cachable
+import cl.emilym.sinatra.data.repository.Preference
+import cl.emilym.sinatra.data.repository.PreferencesRepository
+import cl.emilym.sinatra.data.repository.PreferencesUnit
+import cl.emilym.sinatra.data.repository.RouteRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GetFilteredRoutesUseCaseTest {
+
+    private val routeRepository = mockk<RouteRepository>()
+    private val preferencesRepository = mockk<PreferencesRepository>()
+    private val useCase = GetFilteredRoutesUseCase(routeRepository, preferencesRepository)
+
+    // Create test routes based on DefaultRoute
+    private val regularRoute1 = DefaultRoute.copy(
+        id = "route1",
+        name = "Regular Route 1",
+        schoolServiceOnly = false
+    )
+
+    private val regularRoute2 = DefaultRoute.copy(
+        id = "route2",
+        name = "Regular Route 2",
+        schoolServiceOnly = false
+    )
+
+    private val schoolRoute1 = DefaultRoute.copy(
+        id = "school1",
+        name = "School Route 1",
+        schoolServiceOnly = true
+    )
+
+    private val schoolRoute2 = DefaultRoute.copy(
+        id = "school2",
+        name = "School Route 2",
+        schoolServiceOnly = true
+    )
+
+    private val allRoutes = listOf(regularRoute1, regularRoute2, schoolRoute1, schoolRoute2)
+    private val nonSchoolRoutes = listOf(regularRoute1, regularRoute2)
+
+    @Test
+    fun `invoke should return all routes when ShowSchoolServices preference is true`() = runTest {
+        // Given
+        val cachableRoutes = Cachable.live(allRoutes)
+        coEvery { routeRepository.routes() } returns cachableRoutes
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(true)
+        }
+
+        // When
+        val result = useCase().toList()
+
+        // Then
+        assertEquals(1, result.size)
+        assertEquals(allRoutes.filterAndSort(), result[0].item)
+        coVerify { routeRepository.routes() }
+        verify { preferencesRepository.preference(Preference.ShowSchoolServices) }
+    }
+
+    @Test
+    fun `invoke should filter out school services when ShowSchoolServices preference is false`() = runTest {
+        // Given
+        val cachableRoutes = Cachable.live(allRoutes)
+        coEvery { routeRepository.routes() } returns cachableRoutes
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(false)
+        }
+
+        // When
+        val result = useCase().toList()
+
+        // Then
+        assertEquals(1, result.size)
+        val filteredResult = result[0]
+        assertEquals(nonSchoolRoutes.filterAndSort(), filteredResult.item)
+
+        // Verify no school service routes are included
+        filteredResult.item.forEach { route ->
+            assertFalse(route.schoolServiceOnly, "Route ${route.name} should not be school service only")
+        }
+
+        coVerify { routeRepository.routes() }
+        verify { preferencesRepository.preference(Preference.ShowSchoolServices) }
+    }
+
+    @Test
+    fun `invoke should handle only school service routes when preference is false`() = runTest {
+        // Given
+        val schoolOnlyRoutes = listOf(schoolRoute1, schoolRoute2)
+        val cachableRoutes = Cachable.live(schoolOnlyRoutes)
+        coEvery { routeRepository.routes() } returns cachableRoutes
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(false)
+        }
+
+        // When
+        val result = useCase().toList()
+
+        // Then
+        assertEquals(1, result.size)
+        val filteredResult = result[0]
+        assertTrue(filteredResult.item.isEmpty(), "All school service routes should be filtered out")
+    }
+
+    @Test
+    fun `invoke should handle only regular routes when preference is false`() = runTest {
+        // Given
+        val regularOnlyRoutes = listOf(regularRoute1, regularRoute2)
+        val cachableRoutes = Cachable.live(regularOnlyRoutes)
+        coEvery { routeRepository.routes() } returns cachableRoutes
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(false)
+        }
+
+        // When
+        val result = useCase().toList()
+
+        // Then
+        assertEquals(1, result.size)
+        val filteredResult = result[0]
+        assertEquals(regularOnlyRoutes.filterAndSort(), filteredResult.item)
+        filteredResult.item.forEach { route ->
+            assertFalse(route.schoolServiceOnly)
+        }
+    }
+
+    @Test
+    fun `invoke should react to preference changes`() = runTest {
+        // Given
+        val cachableRoutes = Cachable.live(allRoutes)
+        coEvery { routeRepository.routes() } returns cachableRoutes
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(false, true, false)
+        }
+
+        // When
+        val result = useCase().toList()
+
+        // Then
+        assertEquals(3, result.size)
+
+        // First emission (preference = false) - filtered
+        val firstResult = result[0]
+        assertEquals(nonSchoolRoutes.filterAndSort(), firstResult.item)
+
+        // Second emission (preference = true) - all routes
+        val secondResult = result[1]
+        assertEquals(allRoutes.filterAndSort(), secondResult.item)
+
+        // Third emission (preference = false) - filtered again
+        val thirdResult = result[2]
+        assertEquals(nonSchoolRoutes.filterAndSort(), thirdResult.item)
+    }
+
+    @Test
+    fun `filterRoutes should return all routes when ShowSchoolServices preference is true`() = runTest {
+        // Given
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(true)
+        }
+
+        // When
+        val result = useCase.filterRoutes(allRoutes).toList()
+
+        // Then
+        assertEquals(1, result.size)
+        assertEquals(allRoutes.filterAndSort(), result[0])
+    }
+
+    @Test
+    fun `filterRoutes should filter out school services when ShowSchoolServices preference is false`() = runTest {
+        // Given
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(false)
+        }
+
+        // When
+        val result = useCase.filterRoutes(allRoutes).toList()
+
+        // Then
+        assertEquals(1, result.size)
+        assertEquals(nonSchoolRoutes.filterAndSort(), result[0])
+
+        // Verify no school service routes are included
+        result[0].forEach { route ->
+            assertFalse(route.schoolServiceOnly, "Route ${route.name} should not be school service only")
+        }
+    }
+
+    @Test
+    fun `filterRoutes should handle empty routes list when preference is true`() = runTest {
+        // Given
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(true)
+        }
+
+        // When
+        val result = useCase.filterRoutes(emptyList()).toList()
+
+        // Then
+        assertEquals(1, result.size)
+        assertTrue(result[0].isEmpty())
+    }
+
+    @Test
+    fun `filterRoutes should handle empty routes list when preference is false`() = runTest {
+        // Given
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(false)
+        }
+
+        // When
+        val result = useCase.filterRoutes(emptyList()).toList()
+
+        // Then
+        assertEquals(1, result.size)
+        assertTrue(result[0].isEmpty())
+    }
+
+    @Test
+    fun `filterRoutes should react to preference changes`() = runTest {
+        // Given
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(false, true, false)
+        }
+
+        // When
+        val result = useCase.filterRoutes(allRoutes).toList()
+
+        // Then
+        assertEquals(3, result.size)
+
+        // First emission (preference = false) - filtered
+        assertEquals(nonSchoolRoutes.filterAndSort(), result[0])
+
+        // Second emission (preference = true) - all routes
+        assertEquals(allRoutes.filterAndSort(), result[1])
+
+        // Third emission (preference = false) - filtered again
+        assertEquals(nonSchoolRoutes.filterAndSort(), result[2])
+    }
+}

--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/GetFilteredStopsUseCaseTest.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/GetFilteredStopsUseCaseTest.kt
@@ -1,0 +1,169 @@
+package cl.emilym.sinatra.domain
+
+import cl.emilym.sinatra.DefaultStop
+import cl.emilym.sinatra.data.models.Cachable
+import cl.emilym.sinatra.data.repository.Preference
+import cl.emilym.sinatra.data.repository.PreferencesRepository
+import cl.emilym.sinatra.data.repository.PreferencesUnit
+import cl.emilym.sinatra.data.repository.StopRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GetFilteredStopsUseCaseTest {
+
+    private val stopRepository = mockk<StopRepository>()
+    private val preferencesRepository = mockk<PreferencesRepository>()
+    private val useCase = GetFilteredStopsUseCase(stopRepository, preferencesRepository)
+
+    // Create test stops based on DefaultStop
+    private val regularStop1 = DefaultStop.copy(
+        id = "stop1",
+        name = "Regular Stop 1",
+        schoolServiceOnly = false
+    )
+
+    private val regularStop2 = DefaultStop.copy(
+        id = "stop2",
+        name = "Regular Stop 2",
+        schoolServiceOnly = false
+    )
+
+    private val schoolStop1 = DefaultStop.copy(
+        id = "school1",
+        name = "School Stop 1",
+        schoolServiceOnly = true
+    )
+
+    private val schoolStop2 = DefaultStop.copy(
+        id = "school2",
+        name = "School Stop 2",
+        schoolServiceOnly = true
+    )
+
+    private val allStops = listOf(regularStop1, regularStop2, schoolStop1, schoolStop2)
+    private val nonSchoolStops = listOf(regularStop1, regularStop2)
+
+    @Test
+    fun `invoke should return all stops when ShowSchoolServices preference is true`() = runTest {
+        // Given
+        val cachableStops = Cachable.live(allStops)
+        coEvery { stopRepository.stops() } returns cachableStops
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(true)
+        }
+
+        // When
+        val result = useCase().toList()
+
+        // Then
+        assertEquals(1, result.size)
+        assertEquals(cachableStops, result[0])
+        coVerify { stopRepository.stops() }
+        verify { preferencesRepository.preference(Preference.ShowSchoolServices) }
+    }
+
+    @Test
+    fun `invoke should filter out school services when ShowSchoolServices preference is false`() = runTest {
+        // Given
+        val cachableStops = Cachable.live(allStops)
+        coEvery { stopRepository.stops() } returns cachableStops
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(false)
+        }
+
+        // When
+        val result = useCase().toList()
+
+        // Then
+        assertEquals(1, result.size)
+        val filteredResult = result[0]
+        assertEquals(nonSchoolStops, filteredResult.item)
+
+        // Verify no school service stops are included
+        filteredResult.item.forEach { stop ->
+            assertFalse(stop.schoolServiceOnly, "Stop ${stop.name} should not be school service only")
+        }
+
+        coVerify { stopRepository.stops() }
+        verify { preferencesRepository.preference(Preference.ShowSchoolServices) }
+    }
+
+    @Test
+    fun `invoke should handle only school service stops when preference is false`() = runTest {
+        // Given
+        val schoolOnlyStops = listOf(schoolStop1, schoolStop2)
+        val cachableStops = Cachable.live(schoolOnlyStops)
+        coEvery { stopRepository.stops() } returns cachableStops
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(false)
+        }
+
+        // When
+        val result = useCase().toList()
+
+        // Then
+        assertEquals(1, result.size)
+        val filteredResult = result[0]
+        assertTrue(filteredResult.item.isEmpty(), "All school service stops should be filtered out")
+    }
+
+    @Test
+    fun `invoke should handle only regular stops when preference is false`() = runTest {
+        // Given
+        val regularOnlyStops = listOf(regularStop1, regularStop2)
+        val cachableStops = Cachable.live(regularOnlyStops)
+        coEvery { stopRepository.stops() } returns cachableStops
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(false)
+        }
+
+        // When
+        val result = useCase().toList()
+
+        // Then
+        assertEquals(1, result.size)
+        val filteredResult = result[0]
+        assertEquals(regularOnlyStops, filteredResult.item)
+        filteredResult.item.forEach { stop ->
+            assertFalse(stop.schoolServiceOnly)
+        }
+    }
+
+    @Test
+    fun `invoke should react to preference changes`() = runTest {
+        // Given
+        val cachableStops = Cachable.live(allStops)
+        coEvery { stopRepository.stops() } returns cachableStops
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(false, true, false)
+        }
+
+        // When
+        val result = useCase().toList()
+
+        // Then
+        assertEquals(3, result.size)
+
+        // First emission (preference = false) - filtered
+        val firstResult = result[0]
+        assertEquals(nonSchoolStops, firstResult.item)
+
+        // Second emission (preference = true) - all stops
+        val secondResult = result[1]
+        assertEquals(allStops, secondResult.item)
+
+        // Third emission (preference = false) - filtered again
+        val thirdResult = result[2]
+        assertEquals(nonSchoolStops, thirdResult.item)
+    }
+}

--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/LastDepartureForStopUseCaseTest.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/LastDepartureForStopUseCaseTest.kt
@@ -1,9 +1,11 @@
 package cl.emilym.sinatra.domain
 
+import cl.emilym.sinatra.DefaultRoute
 import cl.emilym.sinatra.DefaultService
 import cl.emilym.sinatra.DefaultStopTimetableTime
 import cl.emilym.sinatra.FeatureFlag
 import cl.emilym.sinatra.data.models.Cachable
+import cl.emilym.sinatra.data.models.IStopTimetableTime
 import cl.emilym.sinatra.data.models.Service
 import cl.emilym.sinatra.data.models.StopId
 import cl.emilym.sinatra.data.models.StopTimetableTime
@@ -29,6 +31,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.days
@@ -690,6 +693,289 @@ class LastDepartureForStopUseCaseTest {
         assertEquals(1, result.size)
         assertEquals("tomorrow-service", result.first().serviceId)
         assertEquals(1.hours, result.first().departureTime.durationThroughDay)
+    }
+
+    @Test
+    fun `invoke filters out school services when ShowSchoolServices is false`() = runTest {
+        // Given
+        val activeService = mockk<Service>()
+        val schoolRoute = DefaultRoute.copy(
+            schoolServiceOnly = true
+        )
+        val regularRoute = DefaultRoute
+
+        val schoolServiceTime = DefaultStopTimetableTime.copy(
+            serviceId = "service1",
+            routeId = "school-route",
+            heading = "School",
+            departureTime = Time.create(1.hours),
+            route = schoolRoute
+        )
+
+        val regularServiceTime = DefaultStopTimetableTime.copy(
+            serviceId = "service1",
+            routeId = "regular-route",
+            heading = "City",
+            departureTime = Time.create(2.hours),
+            route = regularRoute
+        )
+
+        val servicesAndTimes = createServicesAndTimes(
+            services = listOf(activeService),
+            times = listOf(schoolServiceTime, regularServiceTime)
+        )
+
+        every { activeService.id } returns "service1"
+        every { activeService.active(any(), any()) } returns true
+
+        // Mock ShowSchoolServices preference as false
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(false)
+        }
+
+        coEvery { servicesAndTimesForStopUseCase(testStopId) } returns servicesAndTimes
+
+        // When
+        val result = useCase(testStopId).first()
+
+        // Then
+        assertEquals(1, result.size)
+        assertEquals("regular-route", result.first().routeId)
+        assertEquals("City", result.first().heading)
+    }
+
+    @Test
+    fun `invoke includes school services when ShowSchoolServices is true`() = runTest {
+        // Given
+        val activeService = mockk<Service>()
+        val schoolRoute = DefaultRoute.copy(schoolServiceOnly = true)
+        val regularRoute = DefaultRoute
+
+        val schoolServiceTime = DefaultStopTimetableTime.copy(
+            serviceId = "service1",
+            routeId = "school-route",
+            heading = "School",
+            departureTime = Time.create(1.hours),
+            route = schoolRoute
+        )
+
+        val regularServiceTime = DefaultStopTimetableTime.copy(
+            serviceId = "service1",
+            routeId = "regular-route",
+            heading = "City",
+            departureTime = Time.create(2.hours),
+            route = regularRoute
+        )
+
+        val servicesAndTimes = createServicesAndTimes(
+            services = listOf(activeService),
+            times = listOf(schoolServiceTime, regularServiceTime)
+        )
+
+        every { activeService.id } returns "service1"
+        every { activeService.active(any(), any()) } returns true
+
+        // Mock ShowSchoolServices preference as true
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(true)
+        }
+
+        coEvery { servicesAndTimesForStopUseCase(testStopId) } returns servicesAndTimes
+
+        // When
+        val result = useCase(testStopId).first()
+
+        // Then
+        assertEquals(2, result.size)
+        val routes = result.map { it.routeId }.toSet()
+        assertTrue(routes.contains("school-route"))
+        assertTrue(routes.contains("regular-route"))
+    }
+
+    @Test
+    fun `invoke handles null route gracefully when filtering school services`() = runTest {
+        // Given
+        val activeService = mockk<Service>()
+
+        val nullRouteServiceTime = DefaultStopTimetableTime.copy(
+            serviceId = "service1",
+            routeId = "null-route",
+            heading = "City",
+            departureTime = Time.create(1.hours),
+            route = null
+        )
+
+        val servicesAndTimes = createServicesAndTimes(
+            services = listOf(activeService),
+            times = listOf(nullRouteServiceTime)
+        )
+
+        every { activeService.id } returns "service1"
+        every { activeService.active(any(), any()) } returns true
+
+        // Mock ShowSchoolServices preference as false
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(false)
+        }
+
+        coEvery { servicesAndTimesForStopUseCase(testStopId) } returns servicesAndTimes
+
+        // When
+        val result = useCase(testStopId).first()
+
+        // Then
+        assertEquals(0, result.size) // null route should not be included
+    }
+
+    @Test
+    fun `invoke returns only school services when only school services available and preference is true`() = runTest {
+        // Given
+        val activeService = mockk<Service>()
+        val schoolRoute = mockk<cl.emilym.sinatra.data.models.Route>()
+
+        val schoolServiceTime = DefaultStopTimetableTime.copy(
+            serviceId = "service1",
+            routeId = "school-route",
+            heading = "School",
+            departureTime = Time.create(1.hours),
+            route = schoolRoute
+        )
+
+        val servicesAndTimes = createServicesAndTimes(
+            services = listOf(activeService),
+            times = listOf(schoolServiceTime)
+        )
+
+        every { activeService.id } returns "service1"
+        every { activeService.active(any(), any()) } returns true
+        every { schoolRoute.schoolServiceOnly } returns true
+
+        // Mock ShowSchoolServices preference as true
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(true)
+        }
+
+        coEvery { servicesAndTimesForStopUseCase(testStopId) } returns servicesAndTimes
+
+        // When
+        val result = useCase(testStopId).first()
+
+        // Then
+        assertEquals(1, result.size)
+        assertEquals("school-route", result.first().routeId)
+    }
+
+    @Test
+    fun `invoke returns empty list when only school services available and preference is false`() = runTest {
+        // Given
+        val activeService = mockk<Service>()
+        val schoolRoute = mockk<cl.emilym.sinatra.data.models.Route>()
+
+        val schoolServiceTime = DefaultStopTimetableTime.copy(
+            serviceId = "service1",
+            routeId = "school-route",
+            heading = "School",
+            departureTime = Time.create(1.hours),
+            route = schoolRoute
+        )
+
+        val servicesAndTimes = createServicesAndTimes(
+            services = listOf(activeService),
+            times = listOf(schoolServiceTime)
+        )
+
+        every { activeService.id } returns "service1"
+        every { activeService.active(any(), any()) } returns true
+        every { schoolRoute.schoolServiceOnly } returns true
+
+        // Mock ShowSchoolServices preference as false
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(false)
+        }
+
+        coEvery { servicesAndTimesForStopUseCase(testStopId) } returns servicesAndTimes
+
+        // When
+        val result = useCase(testStopId).first()
+
+        // Then
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `invoke handles mixed school and regular services with preference changes`() = runTest {
+        // Given
+        val activeService = mockk<Service>()
+        val schoolRoute = DefaultRoute.copy(schoolServiceOnly = true)
+        val regularRoute1 = DefaultRoute
+        val regularRoute2 = DefaultRoute
+
+        val schoolServiceTime = DefaultStopTimetableTime.copy(
+            serviceId = "service1",
+            routeId = "school-route",
+            heading = "School",
+            departureTime = Time.create(1.hours),
+            route = schoolRoute
+        )
+
+        val regularServiceTime1 = DefaultStopTimetableTime.copy(
+            serviceId = "service1",
+            routeId = "regular-route-1",
+            heading = "City",
+            departureTime = Time.create(2.hours),
+            route = regularRoute1
+        )
+
+        val regularServiceTime2 = DefaultStopTimetableTime.copy(
+            serviceId = "service1",
+            routeId = "regular-route-2",
+            heading = "Airport",
+            departureTime = Time.create(3.hours),
+            route = regularRoute2
+        )
+
+        val servicesAndTimes = createServicesAndTimes(
+            services = listOf(activeService),
+            times = listOf(schoolServiceTime, regularServiceTime1, regularServiceTime2)
+        )
+
+        every { activeService.id } returns "service1"
+        every { activeService.active(any(), any()) } returns true
+
+        // Mock ShowSchoolServices preference changing from false to true to false
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(false, true, false)
+        }
+
+        coEvery { servicesAndTimesForStopUseCase(testStopId) } returns servicesAndTimes
+
+        // When
+        val results = mutableListOf<List<IStopTimetableTime>>()
+        useCase(testStopId).collect { results.add(it) }
+
+        // Then
+        assertEquals(3, results.size)
+
+        // First emission (preference = false): only regular services
+        assertEquals(2, results[0].size)
+        val firstRoutes = results[0].map { it.routeId }.toSet()
+        assertFalse(firstRoutes.contains("school-route"))
+        assertTrue(firstRoutes.contains("regular-route-1"))
+        assertTrue(firstRoutes.contains("regular-route-2"))
+
+        // Second emission (preference = true): all services
+        assertEquals(3, results[1].size)
+        val secondRoutes = results[1].map { it.routeId }.toSet()
+        assertTrue(secondRoutes.contains("school-route"))
+        assertTrue(secondRoutes.contains("regular-route-1"))
+        assertTrue(secondRoutes.contains("regular-route-2"))
+
+        // Third emission (preference = false): only regular services again
+        assertEquals(2, results[2].size)
+        val thirdRoutes = results[2].map { it.routeId }.toSet()
+        assertFalse(thirdRoutes.contains("school-route"))
+        assertTrue(thirdRoutes.contains("regular-route-1"))
+        assertTrue(thirdRoutes.contains("regular-route-2"))
     }
 
     // Helper functions

--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/LastDepartureForStopUseCaseTest.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/LastDepartureForStopUseCaseTest.kt
@@ -8,6 +8,9 @@ import cl.emilym.sinatra.data.models.Service
 import cl.emilym.sinatra.data.models.StopId
 import cl.emilym.sinatra.data.models.StopTimetableTime
 import cl.emilym.sinatra.data.models.Time
+import cl.emilym.sinatra.data.repository.Preference
+import cl.emilym.sinatra.data.repository.PreferencesRepository
+import cl.emilym.sinatra.data.repository.PreferencesUnit
 import cl.emilym.sinatra.data.repository.RemoteConfigRepository
 import cl.emilym.sinatra.data.repository.TransportMetadataRepository
 import io.mockk.clearAllMocks
@@ -17,6 +20,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
@@ -36,12 +40,14 @@ class LastDepartureForStopUseCaseTest {
     private val metadataRepository = mockk<TransportMetadataRepository>()
     private val remoteConfigRepository = mockk<RemoteConfigRepository>()
     private val clock = mockk<Clock>()
+    private val preferencesRepository = mockk<PreferencesRepository>()
 
     private val useCase = LastDepartureForStopUseCase(
         servicesAndTimesForStopUseCase,
         metadataRepository,
         remoteConfigRepository,
-        clock
+        clock,
+        preferencesRepository
     )
 
     private val testTimeZone = TimeZone.of("Australia/Sydney")
@@ -57,6 +63,9 @@ class LastDepartureForStopUseCaseTest {
         every { clock.now() } returns baseTime
         coEvery { metadataRepository.timeZone() } returns testTimeZone
         coEvery { remoteConfigRepository.feature(any<FeatureFlag>()) } returns false
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(false)
+        }
     }
 
     @AfterTest

--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/LiveStopTimetableUseCaseTest.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/LiveStopTimetableUseCaseTest.kt
@@ -94,6 +94,7 @@ class LiveStopTimetableUseCaseTest {
                     ),
                     false,
                     null,
+                    false,
                 ),
                 null
             )
@@ -110,7 +111,7 @@ class LiveStopTimetableUseCaseTest {
         )
         coEvery { liveServiceRepository.getStopRealtimeUpdates(any()) } returns flowOf(updates)
         coEvery { stopRepository.stop(sId) } returns Cachable.live(Stop("stop1", null, "Stop 1", "Stop 1",
-            MapLocation(0.0,0.0,), StopAccessibility(StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), true
+            MapLocation(0.0,0.0,), StopAccessibility(StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), true, false
         ))
 
         val result = useCase(sId, scheduled).toList()
@@ -155,7 +156,8 @@ class LiveStopTimetableUseCaseTest {
                         false
                     ),
                     false,
-                    null
+                    null,
+                    false,
                 ),
                 null
             )
@@ -172,7 +174,7 @@ class LiveStopTimetableUseCaseTest {
         )
         coEvery { liveServiceRepository.getStopRealtimeUpdates(any()) } returns flowOf(updates)
         coEvery { stopRepository.stop(stopId) } returns Cachable.live(Stop("stop1", null, "Stop 1", "Stop 1",
-            MapLocation(0.0,0.0,), StopAccessibility(StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), true
+            MapLocation(0.0,0.0,), StopAccessibility(StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), true, false
         ))
 
         val result = useCase(stopId, scheduled).toList()
@@ -213,7 +215,8 @@ class LiveStopTimetableUseCaseTest {
                         false
                     ),
                     false,
-                    null
+                    null,
+                    false
                 ),
                 null
             )
@@ -230,7 +233,7 @@ class LiveStopTimetableUseCaseTest {
         )
         coEvery { liveServiceRepository.getStopRealtimeUpdates(any()) } returns flowOf(updates)
         coEvery { stopRepository.stop(stopId) } returns Cachable.live(Stop("stop1", null, "Stop 1", "Stop 1",
-            MapLocation(0.0,0.0,), StopAccessibility(StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), true
+            MapLocation(0.0,0.0,), StopAccessibility(StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), true, false
         ))
 
         val result = useCase(stopId, scheduled).toList()
@@ -271,14 +274,15 @@ class LiveStopTimetableUseCaseTest {
                         false
                     ),
                     false,
-                    null
+                    null,
+                    false,
                 ),
                 null
             )
         )
 
         coEvery { stopRepository.stop(stopId) } returns Cachable.live(Stop("stop1", null, "Stop 1", "Stop 1",
-            MapLocation(0.0,0.0,), StopAccessibility(StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false
+            MapLocation(0.0,0.0,), StopAccessibility(StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false, false
         ))
 
         val result = useCase(stopId, scheduled).toList()
@@ -320,14 +324,15 @@ class LiveStopTimetableUseCaseTest {
                         false
                     ),
                     false,
-                    null
+                    null,
+                    false,
                 ),
                 null
             )
         )
         coEvery { liveServiceRepository.getStopRealtimeUpdates(any()) } throws Exception("Network error")
         coEvery { stopRepository.stop(stopId) } returns Cachable.live(Stop("stop1", null, "Stop 1", "Stop 1",
-            MapLocation(0.0,0.0,), StopAccessibility(StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), true
+            MapLocation(0.0,0.0,), StopAccessibility(StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), true, false
         ))
 
         val result = useCase(stopId, scheduled).toList()

--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/UpcomingRoutesForStopUseCaseTest.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/UpcomingRoutesForStopUseCaseTest.kt
@@ -1,5 +1,6 @@
 package cl.emilym.sinatra.domain
 
+import cl.emilym.sinatra.DefaultRoute
 import cl.emilym.sinatra.FeatureFlag
 import cl.emilym.sinatra.data.models.Cachable
 import cl.emilym.sinatra.data.models.Service
@@ -7,6 +8,9 @@ import cl.emilym.sinatra.data.models.StopTimetable
 import cl.emilym.sinatra.data.models.StopTimetableTime
 import cl.emilym.sinatra.data.models.Time
 import cl.emilym.sinatra.data.models.startOfDay
+import cl.emilym.sinatra.data.repository.Preference
+import cl.emilym.sinatra.data.repository.PreferencesRepository
+import cl.emilym.sinatra.data.repository.PreferencesUnit
 import cl.emilym.sinatra.data.repository.RemoteConfigRepository
 import cl.emilym.sinatra.data.repository.ServiceRepository
 import cl.emilym.sinatra.data.repository.StopRepository
@@ -36,6 +40,7 @@ class UpcomingRoutesForStopUseCaseTest {
     private lateinit var servicesAndTimesForStopUseCase: ServicesAndTimesForStopUseCase
     private lateinit var metadataRepository: TransportMetadataRepository
     private lateinit var remoteConfigRepository: RemoteConfigRepository
+    private lateinit var preferencesRepository: PreferencesRepository
     private lateinit var clock: Clock
     private lateinit var useCase: UpcomingRoutesForStopUseCase
     private lateinit var service: Service
@@ -46,6 +51,7 @@ class UpcomingRoutesForStopUseCaseTest {
         servicesAndTimesForStopUseCase = mockk()
         metadataRepository = mockk()
         remoteConfigRepository = mockk()
+        preferencesRepository = mockk()
         clock = mockk()
         service = mockk()
         useCase = UpcomingRoutesForStopUseCase(
@@ -53,11 +59,15 @@ class UpcomingRoutesForStopUseCaseTest {
             servicesAndTimesForStopUseCase,
             clock,
             metadataRepository,
-            remoteConfigRepository
+            preferencesRepository,
+            remoteConfigRepository,
         )
 
         every { service.id } returns "service-1"
         coEvery { remoteConfigRepository.feature(any()) } returns true
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(false)
+        }
     }
 
     @Test
@@ -78,7 +88,7 @@ class UpcomingRoutesForStopUseCaseTest {
                 heading = "North",
                 sequence = 1,
                 last = false,
-                route = null,
+                route = DefaultRoute,
                 childStop = null
             )
         )
@@ -153,7 +163,7 @@ class UpcomingRoutesForStopUseCaseTest {
                 heading = "North",
                 sequence = 1,
                 last = false,
-                route = null,
+                route = DefaultRoute,
                 childStop = null
             )
         )
@@ -170,7 +180,7 @@ class UpcomingRoutesForStopUseCaseTest {
                 heading = "South",
                 sequence = 2,
                 last = false,
-                route = null,
+                route = DefaultRoute,
                 childStop = null
             )
         )
@@ -218,7 +228,7 @@ class UpcomingRoutesForStopUseCaseTest {
                 heading = "North",
                 sequence = 1,
                 last = false,
-                route = null,
+                route = DefaultRoute,
                 childStop = null
             ),
             StopTimetableTime(
@@ -232,7 +242,7 @@ class UpcomingRoutesForStopUseCaseTest {
                 heading = "North",
                 sequence = 1,
                 last = false,
-                route = null,
+                route = DefaultRoute,
                 childStop = null
             )
         )
@@ -283,7 +293,7 @@ class UpcomingRoutesForStopUseCaseTest {
                 heading = "South",
                 sequence = 1,
                 last = false,
-                route = null,
+                route = DefaultRoute,
                 childStop = null
             ),
             // Current day time that has already passed
@@ -298,7 +308,7 @@ class UpcomingRoutesForStopUseCaseTest {
                 heading = "North",
                 sequence = 1,
                 last = false,
-                route = null,
+                route = DefaultRoute,
                 childStop = null
             ),
         )
@@ -349,7 +359,7 @@ class UpcomingRoutesForStopUseCaseTest {
                 heading = "North",
                 sequence = 1,
                 last = false,
-                route = null,
+                route = DefaultRoute,
                 childStop = null
             ),
             // Next day time
@@ -364,7 +374,7 @@ class UpcomingRoutesForStopUseCaseTest {
                 heading = "South",
                 sequence = 1,
                 last = false,
-                route = null,
+                route = DefaultRoute,
                 childStop = null
             )
         )
@@ -412,7 +422,7 @@ class UpcomingRoutesForStopUseCaseTest {
                 heading = "North",
                 sequence = 1,
                 last = false,
-                route = null,
+                route = DefaultRoute,
                 childStop = null
             ),
             // Next day time
@@ -427,7 +437,7 @@ class UpcomingRoutesForStopUseCaseTest {
                 heading = "South",
                 sequence = 1,
                 last = false,
-                route = null,
+                route = DefaultRoute,
                 childStop = null
             )
         )
@@ -477,7 +487,7 @@ class UpcomingRoutesForStopUseCaseTest {
                 heading = "South",
                 sequence = 1,
                 last = false,
-                route = null,
+                route = DefaultRoute,
                 childStop = null
             ),
             // Current day time that is still upcoming
@@ -492,7 +502,7 @@ class UpcomingRoutesForStopUseCaseTest {
                 heading = "North",
                 sequence = 1,
                 last = false,
-                route = null,
+                route = DefaultRoute,
                 childStop = null
             ),
         )
@@ -547,7 +557,7 @@ class UpcomingRoutesForStopUseCaseTest {
                 heading = "South",
                 sequence = 1,
                 last = false,
-                route = null,
+                route = DefaultRoute,
                 childStop = null
             ),
             StopTimetableTime(
@@ -561,7 +571,7 @@ class UpcomingRoutesForStopUseCaseTest {
                 heading = "East",
                 sequence = 1,
                 last = false,
-                route = null,
+                route = DefaultRoute,
                 childStop = null
             ),
             // Current day time
@@ -576,7 +586,7 @@ class UpcomingRoutesForStopUseCaseTest {
                 heading = "North",
                 sequence = 1,
                 last = false,
-                route = null,
+                route = DefaultRoute,
                 childStop = null
             ),
         )

--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/UpcomingRoutesForStopUseCaseTest.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/UpcomingRoutesForStopUseCaseTest.kt
@@ -1,6 +1,7 @@
 package cl.emilym.sinatra.domain
 
 import cl.emilym.sinatra.DefaultRoute
+import cl.emilym.sinatra.DefaultStopTimetableTime
 import cl.emilym.sinatra.FeatureFlag
 import cl.emilym.sinatra.data.models.Cachable
 import cl.emilym.sinatra.data.models.Service
@@ -31,6 +32,8 @@ import kotlinx.datetime.TimeZone
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.days
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -619,4 +622,289 @@ class UpcomingRoutesForStopUseCaseTest {
         coVerify { remoteConfigRepository.feature(FeatureFlag.UPCOMING_ROUTES_INCLUDE_NEXT_DAY) }
         verify { clock.now() }
     }
+
+    @Test
+    fun `should filter out school services when ShowSchoolServices is false`() = runTest {
+        val stopId = "stop-123"
+        val timeZone = TimeZone.UTC
+        val currentTime = Instant.parse("2024-01-01T01:00:00Z")
+
+        val schoolRoute = mockk<cl.emilym.sinatra.data.models.Route>()
+        val regularRoute = mockk<cl.emilym.sinatra.data.models.Route>()
+
+        every { schoolRoute.schoolServiceOnly } returns true
+        every { regularRoute.schoolServiceOnly } returns false
+
+        val timetable = listOf(
+            DefaultStopTimetableTime.copy(
+                routeId = "school-route-1",
+                routeCode = "S1",
+                serviceId = "service-1",
+                tripId = "trip-1",
+                arrivalTime = Time.parse("PT13H"),
+                departureTime = Time.parse("PT13H5M"),
+                heading = "School",
+                route = schoolRoute
+            ),
+            DefaultStopTimetableTime.copy(
+                routeId = "regular-route-1",
+                routeCode = "R1",
+                serviceId = "service-1",
+                tripId = "trip-2",
+                arrivalTime = Time.parse("PT14H"),
+                departureTime = Time.parse("PT14H5M"),
+                heading = "City",
+                route = regularRoute
+            )
+        )
+
+        val services = listOf(service)
+
+        every { service.active(any(), any(), any()) } returns true
+        coEvery { metadataRepository.timeZone() } returns timeZone
+        coEvery { servicesAndTimesForStopUseCase.invoke(stopId) } returns Cachable.live(
+            ServicesAndTimes(
+                services = services,
+                times = timetable
+            )
+        )
+        coEvery { clock.now() } returns currentTime
+
+        // Mock ShowSchoolServices preference as false
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(false)
+        }
+
+        val result = useCase(stopId, number = 10, live = false).take(1).first()
+
+        assertEquals(1, result.item.size)
+        assertEquals("R1", result.item.first().routeCode)
+        assertEquals("regular-route-1", result.item.first().routeId)
+    }
+
+    @Test
+    fun `should include school services when ShowSchoolServices is true`() = runTest {
+        val stopId = "stop-123"
+        val timeZone = TimeZone.UTC
+        val currentTime = Instant.parse("2024-01-01T01:00:00Z")
+
+        val schoolRoute = mockk<cl.emilym.sinatra.data.models.Route>()
+        val regularRoute = mockk<cl.emilym.sinatra.data.models.Route>()
+
+        every { schoolRoute.schoolServiceOnly } returns true
+        every { regularRoute.schoolServiceOnly } returns false
+
+        val timetable = listOf(
+            DefaultStopTimetableTime.copy(
+                routeId = "school-route-1",
+                routeCode = "S1",
+                serviceId = "service-1",
+                tripId = "trip-1",
+                arrivalTime = Time.parse("PT13H"),
+                departureTime = Time.parse("PT13H5M"),
+                heading = "School",
+                route = schoolRoute
+            ),
+            DefaultStopTimetableTime.copy(
+                routeId = "regular-route-1",
+                routeCode = "R1",
+                serviceId = "service-1",
+                tripId = "trip-2",
+                arrivalTime = Time.parse("PT14H"),
+                departureTime = Time.parse("PT14H5M"),
+                heading = "City",
+                route = regularRoute
+            )
+        )
+
+        val services = listOf(service)
+
+        every { service.active(any(), any(), any()) } returns true
+        coEvery { metadataRepository.timeZone() } returns timeZone
+        coEvery { servicesAndTimesForStopUseCase.invoke(stopId) } returns Cachable.live(
+            ServicesAndTimes(
+                services = services,
+                times = timetable
+            )
+        )
+        coEvery { clock.now() } returns currentTime
+
+        // Mock ShowSchoolServices preference as true
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(true)
+        }
+
+        val result = useCase(stopId, number = 10, live = false).take(1).first()
+
+        assertEquals(2, result.item.size)
+        val routeCodes = result.item.map { it.routeCode }.toSet()
+        assertTrue(routeCodes.contains("S1"))
+        assertTrue(routeCodes.contains("R1"))
+    }
+
+    @Test
+    fun `should handle null route gracefully when filtering school services`() = runTest {
+        val stopId = "stop-123"
+        val timeZone = TimeZone.UTC
+        val currentTime = Instant.parse("2024-01-01T01:00:00Z")
+
+        val timetable = listOf(
+            DefaultStopTimetableTime.copy(
+                routeId = "route-with-null",
+                routeCode = "N1",
+                serviceId = "service-1",
+                tripId = "trip-1",
+                arrivalTime = Time.parse("PT13H"),
+                departureTime = Time.parse("PT13H5M"),
+                heading = "City",
+                route = null // null route
+            )
+        )
+
+        val services = listOf(service)
+
+        every { service.active(any(), any(), any()) } returns true
+        coEvery { metadataRepository.timeZone() } returns timeZone
+        coEvery { servicesAndTimesForStopUseCase.invoke(stopId) } returns Cachable.live(
+            ServicesAndTimes(
+                services = services,
+                times = timetable
+            )
+        )
+        coEvery { clock.now() } returns currentTime
+
+        // Mock ShowSchoolServices preference as false
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(false)
+        }
+
+        val result = useCase(stopId, number = 10, live = false).take(1).first()
+
+        // Should exclude the null route service
+        assertEquals(0, result.item.size)
+    }
+
+    @Test
+    fun `should return empty list when only school services available and ShowSchoolServices is false`() = runTest {
+        val stopId = "stop-123"
+        val timeZone = TimeZone.UTC
+        val currentTime = Instant.parse("2024-01-01T01:00:00Z")
+
+        val schoolRoute = mockk<cl.emilym.sinatra.data.models.Route>()
+        every { schoolRoute.schoolServiceOnly } returns true
+
+        val timetable = listOf(
+            DefaultStopTimetableTime.copy(
+                routeId = "school-route-1",
+                routeCode = "S1",
+                serviceId = "service-1",
+                tripId = "trip-1",
+                arrivalTime = Time.parse("PT13H"),
+                departureTime = Time.parse("PT13H5M"),
+                heading = "School",
+                route = schoolRoute
+            ),
+            DefaultStopTimetableTime.copy(
+                routeId = "school-route-2",
+                routeCode = "S2",
+                serviceId = "service-1",
+                tripId = "trip-2",
+                arrivalTime = Time.parse("PT14H"),
+                departureTime = Time.parse("PT14H5M"),
+                heading = "School East",
+                route = schoolRoute
+            )
+        )
+
+        val services = listOf(service)
+
+        every { service.active(any(), any(), any()) } returns true
+        coEvery { metadataRepository.timeZone() } returns timeZone
+        coEvery { servicesAndTimesForStopUseCase.invoke(stopId) } returns Cachable.live(
+            ServicesAndTimes(
+                services = services,
+                times = timetable
+            )
+        )
+        coEvery { clock.now() } returns currentTime
+
+        // Mock ShowSchoolServices preference as false
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(false)
+        }
+
+        val result = useCase(stopId, number = 10, live = false).take(1).first()
+
+        assertEquals(0, result.item.size)
+    }
+
+    @Test
+    fun `should respect number limit when filtering school services`() = runTest {
+        val stopId = "stop-123"
+        val timeZone = TimeZone.UTC
+        val currentTime = Instant.parse("2024-01-01T01:00:00Z")
+
+        val schoolRoute = mockk<cl.emilym.sinatra.data.models.Route>()
+        val regularRoute = mockk<cl.emilym.sinatra.data.models.Route>()
+
+        every { schoolRoute.schoolServiceOnly } returns true
+        every { regularRoute.schoolServiceOnly } returns false
+
+        val timetable = listOf(
+            DefaultStopTimetableTime.copy(
+                routeId = "regular-route-1",
+                routeCode = "R1",
+                serviceId = "service-1",
+                tripId = "trip-1",
+                arrivalTime = Time.parse("PT13H"),
+                departureTime = Time.parse("PT13H5M"),
+                heading = "City",
+                route = regularRoute
+            ),
+            DefaultStopTimetableTime.copy(
+                routeId = "school-route-1",
+                routeCode = "S1",
+                serviceId = "service-1",
+                tripId = "trip-2",
+                arrivalTime = Time.parse("PT14H"),
+                departureTime = Time.parse("PT14H5M"),
+                heading = "School",
+                route = schoolRoute
+            ),
+            DefaultStopTimetableTime.copy(
+                routeId = "regular-route-2",
+                routeCode = "R2",
+                serviceId = "service-1",
+                tripId = "trip-3",
+                arrivalTime = Time.parse("PT15H"),
+                departureTime = Time.parse("PT15H5M"),
+                heading = "Airport",
+                route = regularRoute
+            )
+        )
+
+        val services = listOf(service)
+
+        every { service.active(any(), any(), any()) } returns true
+        coEvery { metadataRepository.timeZone() } returns timeZone
+        coEvery { servicesAndTimesForStopUseCase.invoke(stopId) } returns Cachable.live(
+            ServicesAndTimes(
+                services = services,
+                times = timetable
+            )
+        )
+        coEvery { clock.now() } returns currentTime
+
+        // Mock ShowSchoolServices preference as false
+        every { preferencesRepository.preference(Preference.ShowSchoolServices) } returns mockk<PreferencesUnit<Boolean>>().apply {
+            every { flow } returns flowOf(false)
+        }
+
+        val result = useCase(stopId, number = 1, live = false).take(1).first()
+
+        // Should return only 1 result (first regular service), school service should be filtered out
+        assertEquals(1, result.item.size)
+        assertEquals("R1", result.item.first().routeCode)
+    }
+
 }

--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/navigation/CalculateJourneyUseCaseTest.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/navigation/CalculateJourneyUseCaseTest.kt
@@ -75,11 +75,12 @@ class CalculateJourneyUseCaseTest {
         coEvery { graph.metadata.assumedWalkingSecondsPerKilometer } returns 25U * 60U
         every { clock.now() } returns Instant.fromEpochMilliseconds(1745809143)
         coEvery { directWalkingJourneyUseCase.invoke(any(), any(), any(), any()) } returns null
+        coEvery { routingPreferencesRepository.schoolServiceAllowed() } returns false
     }
 
     @Test
     fun `invoke returns journeys when successful`() = runTest {
-        val stop = Stop("stop1", null, "Stop 1", "Stop 1", location, StopAccessibility(StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false)
+        val stop = Stop("stop1", null, "Stop 1", "Stop 1", location, StopAccessibility(StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false, false)
         val stops = listOf(stop)
 
         coEvery { stopRepository.stops() } returns Cachable.live(stops)
@@ -119,7 +120,7 @@ class CalculateJourneyUseCaseTest {
 
     @Test
     fun `invoke throws RouterException when no journeys found`() = runTest {
-        val stop = Stop("stop1", null, "Stop 1", "Stop 1", location, StopAccessibility(StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false)
+        val stop = Stop("stop1", null, "Stop 1", "Stop 1", location, StopAccessibility(StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false, false)
         val stops = listOf(stop)
 
         coEvery { stopRepository.stops() } returns Cachable.live(stops)
@@ -147,8 +148,8 @@ class CalculateJourneyUseCaseTest {
 
     @Test
     fun `nearbyStops returns correct stop when exact`() = runTest {
-        val stop1 = Stop("stop1", null, "Stop 1", "Stop 1", location, StopAccessibility(StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false)
-        val stop2 = Stop("stop2", null, "Stop 2", "Stop 2", MapLocation(1.0, 1.0), StopAccessibility(StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false)
+        val stop1 = Stop("stop1", null, "Stop 1", "Stop 1", location, StopAccessibility(StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false, false)
+        val stop2 = Stop("stop2", null, "Stop 2", "Stop 2", MapLocation(1.0, 1.0), StopAccessibility(StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false, false)
         val stops = listOf(stop1, stop2)
 
         coEvery { networkGraphRepository.networkGraph(any()) } returns Cachable.live(graph)

--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/navigation/ReconstructJourneyUseCaseTest.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/navigation/ReconstructJourneyUseCaseTest.kt
@@ -50,10 +50,10 @@ class ReconstructJourneyUseCaseTest {
     @Test
     fun `toJourney handles exact journey starting with a transfer and dayIndex increase`() = runTest {
         val startStop = Stop("stop1", null, "Stop 1", "Stop 1", location, StopAccessibility(
-            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false
+            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false, false
         )
         val endStop = Stop("stop2", null, "Stop 2", "Stop 2", location, StopAccessibility(
-            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false
+            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false, false
         )
         val stopsList = listOf(startStop, endStop)
 
@@ -76,7 +76,7 @@ class ReconstructJourneyUseCaseTest {
 
         coEvery { stopRepository.stops() } returns Cachable.live(stopsList)
         coEvery { routeRepository.routes(any()) } returns Cachable.live(listOf(
-            Route("route1", "R1", "R1", null, "R1", null, false, false, RouteType.BUS, null, RouteVisibility(false, null, false), false, null)
+            Route("route1", "R1", "R1", null, "R1", null, false, false, RouteType.BUS, null, RouteVisibility(false, null, false), false, null, false)
         ))
         coEvery { graph.metadata.assumedWalkingSecondsPerKilometer } returns 25U * 60U
 
@@ -104,10 +104,10 @@ class ReconstructJourneyUseCaseTest {
     @Test
     fun `toJourney handles exact journey ending with a transfer`() = runTest {
         val startStop = Stop("stop1", null, "Stop 1", "Stop 1", location, StopAccessibility(
-            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false
+            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false, false
         )
         val endStop = Stop("stop2", null, "Stop 2", "Stop 2", location, StopAccessibility(
-            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false
+            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false, false
         )
         val stopsList = listOf(startStop, endStop)
 
@@ -130,7 +130,7 @@ class ReconstructJourneyUseCaseTest {
 
         coEvery { stopRepository.stops() } returns Cachable.live(stopsList)
         coEvery { routeRepository.routes(any()) } returns Cachable.live(listOf(
-            Route("route1", "R1", "R1", null, "R1", null, false, false, RouteType.BUS, null, RouteVisibility(false, null, false), false, null)
+            Route("route1", "R1", "R1", null, "R1", null, false, false, RouteType.BUS, null, RouteVisibility(false, null, false), false, null, false)
         ))
         coEvery { graph.metadata.assumedWalkingSecondsPerKilometer } returns 25U * 60U
 
@@ -158,19 +158,19 @@ class ReconstructJourneyUseCaseTest {
     @Test
     fun `toJourney handles mid-journey dayIndex increase`() = runTest {
         val stop1 = Stop("stop1", null, "Stop 1", "Stop 1", location, StopAccessibility(
-            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false
+            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false, false
         )
         val stop2 = Stop("stop2", null, "Stop 2", "Stop 2", location, StopAccessibility(
-            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false
+            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false, false
         )
         val stop3 = Stop("stop3", null, "Stop 3", "Stop 3", location, StopAccessibility(
-            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false
+            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false, false
         )
         val stop4 = Stop("stop4", null, "Stop 4", "Stop 4", location, StopAccessibility(
-            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false
+            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false, false
         )
         val stop5 = Stop("stop5", null, "Stop 5", "Stop 5", location, StopAccessibility(
-            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false
+            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false, false
         )
         val stopsList = listOf(stop1, stop2, stop3, stop4, stop5)
 
@@ -213,8 +213,8 @@ class ReconstructJourneyUseCaseTest {
 
         coEvery { stopRepository.stops() } returns Cachable.live(stopsList)
         coEvery { routeRepository.routes(any()) } returns Cachable.live(listOf(
-            Route("route1", "R1", "R1", null, "R1", null, false, false, RouteType.BUS, null, RouteVisibility(false, null, false), false, null),
-            Route("route2", "R2", "R2", null, "R2", null, false, false, RouteType.BUS, null, RouteVisibility(false, null, false), false, null)
+            Route("route1", "R1", "R1", null, "R1", null, false, false, RouteType.BUS, null, RouteVisibility(false, null, false), false, null, false),
+            Route("route2", "R2", "R2", null, "R2", null, false, false, RouteType.BUS, null, RouteVisibility(false, null, false), false, null, false)
         ))
         coEvery { graph.metadata.assumedWalkingSecondsPerKilometer } returns 25U * 60U
 
@@ -248,10 +248,10 @@ class ReconstructJourneyUseCaseTest {
     @Test
     fun `toJourney adds transfer points when non-exact departure and arrival`() = runTest {
         val startStop = Stop("stop1", null, "Stop 1", "Stop 1", location, StopAccessibility(
-            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false
+            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false, false
         )
         val endStop = Stop("stop2", null, "Stop 2", "Stop 2", location, StopAccessibility(
-            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false
+            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false, false
         )
         val stopsList = listOf(startStop, endStop)
 
@@ -270,7 +270,7 @@ class ReconstructJourneyUseCaseTest {
 
         coEvery { stopRepository.stops() } returns Cachable.live(stopsList)
         coEvery { routeRepository.routes(any()) } returns Cachable.live(listOf(
-            Route("route1", "R1", "R1", null, "R1", null, false, false, RouteType.BUS, null, RouteVisibility(false, null, false), false, null)
+            Route("route1", "R1", "R1", null, "R1", null, false, false, RouteType.BUS, null, RouteVisibility(false, null, false), false, null, false)
         ))
         coEvery { graph.metadata.assumedWalkingSecondsPerKilometer } returns 25U * 60U
 
@@ -290,10 +290,10 @@ class ReconstructJourneyUseCaseTest {
     @Test
     fun `toJourney handles simple case`() = runTest {
         val startStop = Stop("stop1", null, "Stop 1", "Stop 1", location, StopAccessibility(
-            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false
+            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false, false
         )
         val endStop = Stop("stop2", null, "Stop 2", "Stop 2", location, StopAccessibility(
-            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false
+            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false, false
         )
         val stopsList = listOf(startStop, endStop)
 
@@ -312,7 +312,7 @@ class ReconstructJourneyUseCaseTest {
 
         coEvery { stopRepository.stops() } returns Cachable.live(stopsList)
         coEvery { routeRepository.routes(any()) } returns Cachable.live(listOf(
-            Route("route1", "R1", "R1", null, "R1", null, false, false, RouteType.BUS, null, RouteVisibility(false, null, false), false, null)
+            Route("route1", "R1", "R1", null, "R1", null, false, false, RouteType.BUS, null, RouteVisibility(false, null, false), false, null, false)
         ))
         coEvery { graph.metadata.assumedWalkingSecondsPerKilometer } returns 25U * 60U
 
@@ -331,10 +331,10 @@ class ReconstructJourneyUseCaseTest {
     @Test
     fun `toJourney correctly translates accessibility information`() = runTest {
         val startStop = Stop("stop1", null, "Stop 1", "Stop 1", location, StopAccessibility(
-            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false
+            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false, false
         )
         val endStop = Stop("stop2", null, "Stop 2", "Stop 2", location, StopAccessibility(
-            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false
+            StopWheelchairAccessibility.FULL), StopVisibility(false, false, false, null), false, false
         )
         val stopsList = listOf(startStop, endStop)
 
@@ -379,7 +379,7 @@ class ReconstructJourneyUseCaseTest {
 
         coEvery { stopRepository.stops() } returns Cachable.live(stopsList)
         coEvery { routeRepository.routes(any()) } returns Cachable.live(listOf(
-            Route("route1", "R1", "R1", null, "R1", null, false, false, RouteType.BUS, null, RouteVisibility(false, null, false), false, null)
+            Route("route1", "R1", "R1", null, "R1", null, false, false, RouteType.BUS, null, RouteVisibility(false, null, false), false, null, false)
         ))
         coEvery { graph.metadata.assumedWalkingSecondsPerKilometer } returns 25U * 60U
 

--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/prompt/FavouriteNearbyStopDeparturesUseCaseTest.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/prompt/FavouriteNearbyStopDeparturesUseCaseTest.kt
@@ -46,7 +46,8 @@ class FavouriteNearbyStopDeparturesUseCaseTest {
         location = MapLocation(0.0, 0.0),
         accessibility = StopAccessibility(StopWheelchairAccessibility.UNKNOWN),
         visibility = StopVisibility(true, true, false, null),
-        hasRealtime = false
+        hasRealtime = false,
+        schoolServiceOnly = false
     )
     private val stop2 = Stop(
         id = "stop2",
@@ -56,7 +57,8 @@ class FavouriteNearbyStopDeparturesUseCaseTest {
         location = MapLocation(0.001, 0.001),
         accessibility = StopAccessibility(StopWheelchairAccessibility.UNKNOWN),
         visibility = StopVisibility(true, true, false, null),
-        hasRealtime = false
+        hasRealtime = false,
+        schoolServiceOnly = false
     )
 
     private val timetableTime = StopTimetableTime(

--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/search/RouteStopSearchUseCaseTest.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/search/RouteStopSearchUseCaseTest.kt
@@ -42,8 +42,8 @@ class RouteStopSearchUseCaseTest {
         // Arrange
         val query = "central station"
         val tokens = listOf("central", "station")
-        val route = Route("1", "R1", "R1", null, "R1", null, false, false, RouteType.BUS, null, RouteVisibility(false, null, false), false, null)
-        val stop = Stop("2", null, "Stop 1", null, MapLocation(0.0, 0.0), StopAccessibility(StopWheelchairAccessibility.FULL), StopVisibility(false, true, false, null), false)
+        val route = Route("1", "R1", "R1", null, "R1", null, false, false, RouteType.BUS, null, RouteVisibility(false, null, false), false, null, false)
+        val stop = Stop("2", null, "Stop 1", null, MapLocation(0.0, 0.0), StopAccessibility(StopWheelchairAccessibility.FULL), StopVisibility(false, true, false, null), false, false)
         val place = Place("3", "Place 1", "Place 1", MapLocation(0.0, 0.0))
 
         val routeResult = RankableResult(route, 0.9)

--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/search/RouteTypeSearcherTest.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/search/RouteTypeSearcherTest.kt
@@ -6,6 +6,7 @@ import cl.emilym.sinatra.data.models.Route
 import cl.emilym.sinatra.data.models.RouteType
 import cl.emilym.sinatra.data.models.RouteVisibility
 import cl.emilym.sinatra.data.repository.RouteRepository
+import cl.emilym.sinatra.domain.GetFilteredRoutesUseCase
 import io.mockk.mockk
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -13,19 +14,19 @@ import kotlin.test.assertEquals
 
 class RouteTypeSearcherTest {
 
-    private lateinit var routeRepository: RouteRepository
+    private lateinit var getFilteredRoutesUseCase: GetFilteredRoutesUseCase
     private lateinit var routeTypeSearcher: RouteTypeSearcher
 
     @BeforeTest
     fun setUp() {
-        routeRepository = mockk()
-        routeTypeSearcher = RouteTypeSearcher(routeRepository)
+        getFilteredRoutesUseCase = mockk()
+        routeTypeSearcher = RouteTypeSearcher(getFilteredRoutesUseCase)
     }
 
     @Test
     fun `scoreMultiplier should return 1_7 when colors is not null`() {
         // Arrange
-        val route = Route("1", "R1", "R1", ColorPair("", OnColor.LIGHT), "R1", null, false, false, RouteType.BUS, null, RouteVisibility(false, null, false), false, null)
+        val route = Route("1", "R1", "R1", ColorPair("", OnColor.LIGHT), "R1", null, false, false, RouteType.BUS, null, RouteVisibility(false, null, false), false, null, false)
 
         // Act
         val multiplier = routeTypeSearcher.scoreMultiplier(route)
@@ -37,7 +38,7 @@ class RouteTypeSearcherTest {
     @Test
     fun `scoreMultiplier should return 0_2 when name is NIS`() {
         // Arrange
-        val route = Route("2", "NIS", "NIS", null, "NIS", null, false, false, RouteType.BUS, null, RouteVisibility(false, null, false), false, null)
+        val route = Route("2", "NIS", "NIS", null, "NIS", null, false, false, RouteType.BUS, null, RouteVisibility(false, null, false), false, null, false)
 
         // Act
         val multiplier = routeTypeSearcher.scoreMultiplier(route)
@@ -49,7 +50,7 @@ class RouteTypeSearcherTest {
     @Test
     fun `scoreMultiplier should return 1_1 for other cases`() {
         // Arrange
-        val route = Route("1", "R1", "R1", null, "R1", null, false, false, RouteType.BUS, null, RouteVisibility(false, null, false), false, null)
+        val route = Route("1", "R1", "R1", null, "R1", null, false, false, RouteType.BUS, null, RouteVisibility(false, null, false), false, null, false)
 
         // Act
         val multiplier = routeTypeSearcher.scoreMultiplier(route)
@@ -61,7 +62,7 @@ class RouteTypeSearcherTest {
     @Test
     fun `wrap should return SearchResult with PlaceResult`() {
         // Arrange
-        val route = Route("1", "R1", "R1", null, "R1", null, false, false, RouteType.BUS, null, RouteVisibility(false, null, false), false, null)
+        val route = Route("1", "R1", "R1", null, "R1", null, false, false, RouteType.BUS, null, RouteVisibility(false, null, false), false, null, false)
 
         // Act
         val result = routeTypeSearcher.wrap(route)

--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/search/StopTypeSearcherTest.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/search/StopTypeSearcherTest.kt
@@ -1,12 +1,16 @@
 package cl.emilym.sinatra.domain.search
 
+import cl.emilym.sinatra.data.models.Cachable
 import cl.emilym.sinatra.data.models.Stop
 import cl.emilym.sinatra.data.models.StopVisibility
 import cl.emilym.sinatra.data.repository.StopRepository
+import cl.emilym.sinatra.domain.GetFilteredStopsUseCase
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -14,35 +18,33 @@ import kotlin.test.assertEquals
 
 class StopTypeSearcherTest {
 
-    private lateinit var stopRepository: StopRepository
+    private lateinit var getFilteredStopsUseCase: GetFilteredStopsUseCase
     private lateinit var stopTypeSearcher: StopTypeSearcher
 
     @BeforeTest
     fun setUp() {
-        stopRepository = mockk()
-        stopTypeSearcher = StopTypeSearcher(stopRepository)
+        getFilteredStopsUseCase = mockk()
+        stopTypeSearcher = StopTypeSearcher(getFilteredStopsUseCase)
     }
 
     @Test
     fun `invoke should return empty list when repository returns no items`() = runBlocking {
         // Arrange
         val tokens = listOf("stop")
-        coEvery { stopRepository.stops() } returns mockk {
-            every { item } returns emptyList()
-        }
+        coEvery { getFilteredStopsUseCase() } returns flowOf(Cachable.live(emptyList()))
 
         // Act
         val result = stopTypeSearcher(tokens)
 
         // Assert
         assertEquals(emptyList(), result)
-        coVerify { stopRepository.stops() }
+        verify { getFilteredStopsUseCase() }
     }
 
     @Test
     fun `scoreMultiplier should return 0_75 for stop with parent station`() {
         // Arrange
-        val stop = Stop("123", "parent123", "Main Street", null, mockk(), mockk(), StopVisibility(false, true, false, null), false)
+        val stop = Stop("123", "parent123", "Main Street", null, mockk(), mockk(), StopVisibility(false, true, false, null), false, false)
 
         // Act
         val multiplier = stopTypeSearcher.scoreMultiplier(stop)
@@ -54,7 +56,7 @@ class StopTypeSearcherTest {
     @Test
     fun `scoreMultiplier should return 1_0 for stop without parent station`() {
         // Arrange
-        val stop = Stop("123", null, "Main Street", null, mockk(), mockk(), StopVisibility(false, true, false, null), false)
+        val stop = Stop("123", null, "Main Street", null, mockk(), mockk(), StopVisibility(false, true, false, null), false, false)
 
         // Act
         val multiplier = stopTypeSearcher.scoreMultiplier(stop)
@@ -66,7 +68,7 @@ class StopTypeSearcherTest {
     @Test
     fun `wrap should return SearchResult with StopResult`() {
         // Arrange
-        val stop = Stop("123", null, "Main Street", "null", mockk(), mockk(), StopVisibility(false, true, false, null), false)
+        val stop = Stop("123", null, "Main Street", "null", mockk(), mockk(), StopVisibility(false, true, false, null), false, false)
 
         // Act
         val result = stopTypeSearcher.wrap(stop)

--- a/shared/src/commonMain/kotlin/cl/emilym/gtfs/gtfs-api.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/gtfs/gtfs-api.kt
@@ -1012,6 +1012,7 @@ public data class Route(
     val description: String? = null,
     val moreLink: String? = null,
     val routeVisibility: cl.emilym.gtfs.RouteVisibility? = null,
+    val schoolService: Boolean? = null,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
 ) : pbandk.Message {
     override operator fun plus(other: pbandk.Message?): cl.emilym.gtfs.Route = protoMergeImpl(other)
@@ -1024,7 +1025,7 @@ public data class Route(
             fullName = "proto.Route",
             messageClass = cl.emilym.gtfs.Route::class,
             messageCompanion = this,
-            fields = buildList(14) {
+            fields = buildList(15) {
                 add(
                     pbandk.FieldDescriptor(
                         messageDescriptor = this@Companion::descriptor,
@@ -1163,6 +1164,16 @@ public data class Route(
                         type = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true),
                         jsonName = "moreLink",
                         value = cl.emilym.gtfs.Route::moreLink
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "schoolService",
+                        number = 15,
+                        type = pbandk.FieldDescriptor.Type.Primitive.Bool(hasPresence = true),
+                        jsonName = "schoolService",
+                        value = cl.emilym.gtfs.Route::schoolService
                     )
                 )
             }
@@ -2598,6 +2609,7 @@ private fun Route.protoMergeImpl(plus: pbandk.Message?): Route = (plus as? Route
         description = plus.description ?: description,
         moreLink = plus.moreLink ?: moreLink,
         routeVisibility = routeVisibility?.plus(plus.routeVisibility) ?: plus.routeVisibility,
+        schoolService = plus.schoolService ?: schoolService,
         unknownFields = unknownFields + plus.unknownFields
     )
 } ?: this
@@ -2618,6 +2630,7 @@ private fun Route.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Route {
     var description: String? = null
     var moreLink: String? = null
     var routeVisibility: cl.emilym.gtfs.RouteVisibility? = null
+    var schoolService: Boolean? = null
 
     val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
         when (_fieldNumber) {
@@ -2635,6 +2648,7 @@ private fun Route.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Route {
             12 -> eventRoute = _fieldValue as Boolean
             13 -> description = _fieldValue as String
             14 -> moreLink = _fieldValue as String
+            15 -> schoolService = _fieldValue as Boolean
         }
     }
 
@@ -2653,7 +2667,7 @@ private fun Route.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Route {
     return Route(id!!, code!!, displayCode, colors,
         name!!, designation, type!!, realTimeUrl,
         hasRealtime, approximateTimings, eventRoute, description,
-        moreLink, routeVisibility, unknownFields)
+        moreLink, routeVisibility, schoolService, unknownFields)
 }
 
 @pbandk.Export

--- a/shared/src/commonMain/kotlin/cl/emilym/gtfs/gtfs-api.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/gtfs/gtfs-api.kt
@@ -802,6 +802,7 @@ public data class Stop(
     val accessibility: cl.emilym.gtfs.StopAccessibility,
     val visibility: cl.emilym.gtfs.StopVisibility? = null,
     val hasRealtime: Boolean? = null,
+    val schoolServiceOnly: Boolean? = null,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
 ) : pbandk.Message {
     override operator fun plus(other: pbandk.Message?): cl.emilym.gtfs.Stop = protoMergeImpl(other)
@@ -814,7 +815,7 @@ public data class Stop(
             fullName = "proto.Stop",
             messageClass = cl.emilym.gtfs.Stop::class,
             messageCompanion = this,
-            fields = buildList(8) {
+            fields = buildList(9) {
                 add(
                     pbandk.FieldDescriptor(
                         messageDescriptor = this@Companion::descriptor,
@@ -893,6 +894,16 @@ public data class Stop(
                         type = pbandk.FieldDescriptor.Type.Primitive.Bool(hasPresence = true),
                         jsonName = "hasRealtime",
                         value = cl.emilym.gtfs.Stop::hasRealtime
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "schoolServiceOnly",
+                        number = 9,
+                        type = pbandk.FieldDescriptor.Type.Primitive.Bool(hasPresence = true),
+                        jsonName = "schoolServiceOnly",
+                        value = cl.emilym.gtfs.Stop::schoolServiceOnly
                     )
                 )
             }
@@ -2498,6 +2509,7 @@ private fun Stop.protoMergeImpl(plus: pbandk.Message?): Stop = (plus as? Stop)?.
         accessibility = accessibility.plus(plus.accessibility),
         visibility = visibility?.plus(plus.visibility) ?: plus.visibility,
         hasRealtime = plus.hasRealtime ?: hasRealtime,
+        schoolServiceOnly = plus.schoolServiceOnly ?: schoolServiceOnly,
         unknownFields = unknownFields + plus.unknownFields
     )
 } ?: this
@@ -2512,6 +2524,7 @@ private fun Stop.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Stop {
     var accessibility: cl.emilym.gtfs.StopAccessibility? = null
     var visibility: cl.emilym.gtfs.StopVisibility? = null
     var hasRealtime: Boolean? = null
+    var schoolServiceOnly: Boolean? = null
 
     val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
         when (_fieldNumber) {
@@ -2523,6 +2536,7 @@ private fun Stop.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Stop {
             6 -> visibility = _fieldValue as cl.emilym.gtfs.StopVisibility
             7 -> simpleName = _fieldValue as String
             8 -> hasRealtime = _fieldValue as Boolean
+            9 -> schoolServiceOnly = _fieldValue as Boolean
         }
     }
 
@@ -2539,7 +2553,8 @@ private fun Stop.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Stop {
         throw pbandk.InvalidProtocolBufferException.missingRequiredField("accessibility")
     }
     return Stop(id!!, parentStation, name!!, simpleName,
-        location!!, accessibility!!, visibility, hasRealtime, unknownFields)
+        location!!, accessibility!!, visibility, hasRealtime,
+        schoolServiceOnly, unknownFields)
 }
 
 private fun StopAccessibility.protoMergeImpl(plus: pbandk.Message?): StopAccessibility = (plus as? StopAccessibility)?.let {

--- a/shared/src/commonMain/kotlin/cl/emilym/gtfs/gtfs-api.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/gtfs/gtfs-api.kt
@@ -1023,7 +1023,7 @@ public data class Route(
     val description: String? = null,
     val moreLink: String? = null,
     val routeVisibility: cl.emilym.gtfs.RouteVisibility? = null,
-    val schoolService: Boolean? = null,
+    val schoolServiceOnly: Boolean? = null,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
 ) : pbandk.Message {
     override operator fun plus(other: pbandk.Message?): cl.emilym.gtfs.Route = protoMergeImpl(other)
@@ -1180,11 +1180,11 @@ public data class Route(
                 add(
                     pbandk.FieldDescriptor(
                         messageDescriptor = this@Companion::descriptor,
-                        name = "schoolService",
+                        name = "schoolServiceOnly",
                         number = 15,
                         type = pbandk.FieldDescriptor.Type.Primitive.Bool(hasPresence = true),
-                        jsonName = "schoolService",
-                        value = cl.emilym.gtfs.Route::schoolService
+                        jsonName = "schoolServiceOnly",
+                        value = cl.emilym.gtfs.Route::schoolServiceOnly
                     )
                 )
             }
@@ -2624,7 +2624,7 @@ private fun Route.protoMergeImpl(plus: pbandk.Message?): Route = (plus as? Route
         description = plus.description ?: description,
         moreLink = plus.moreLink ?: moreLink,
         routeVisibility = routeVisibility?.plus(plus.routeVisibility) ?: plus.routeVisibility,
-        schoolService = plus.schoolService ?: schoolService,
+        schoolServiceOnly = plus.schoolServiceOnly ?: schoolServiceOnly,
         unknownFields = unknownFields + plus.unknownFields
     )
 } ?: this
@@ -2645,7 +2645,7 @@ private fun Route.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Route {
     var description: String? = null
     var moreLink: String? = null
     var routeVisibility: cl.emilym.gtfs.RouteVisibility? = null
-    var schoolService: Boolean? = null
+    var schoolServiceOnly: Boolean? = null
 
     val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
         when (_fieldNumber) {
@@ -2663,7 +2663,7 @@ private fun Route.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Route {
             12 -> eventRoute = _fieldValue as Boolean
             13 -> description = _fieldValue as String
             14 -> moreLink = _fieldValue as String
-            15 -> schoolService = _fieldValue as Boolean
+            15 -> schoolServiceOnly = _fieldValue as Boolean
         }
     }
 
@@ -2682,7 +2682,7 @@ private fun Route.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Route {
     return Route(id!!, code!!, displayCode, colors,
         name!!, designation, type!!, realTimeUrl,
         hasRealtime, approximateTimings, eventRoute, description,
-        moreLink, routeVisibility, schoolService, unknownFields)
+        moreLink, routeVisibility, schoolServiceOnly, unknownFields)
 }
 
 @pbandk.Export

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
@@ -47,7 +47,8 @@ enum class FeatureFlag(
     HOLD_MAP_POINT_DETAIL(true),
     GLOBAL_HIDE_TRANSPORT_ACCESSIBILITY(false),
     UPCOMING_ROUTES_INCLUDE_NEXT_DAY(true),
-    REALTIME_USE_GLOBAL(true);
+    REALTIME_USE_GLOBAL(true),
+    GLOBAL_ENABLE_SCHOOL_SERVICES(false);
 
     val immediate by EnumFeatureFlagDelegate(this)
 }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Route.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Route.kt
@@ -13,7 +13,8 @@ data class Route(
     val designation: String?,
     val routeVisibility: RouteVisibility,
     val eventRoute: Boolean,
-    val moreLink: String?
+    val moreLink: String?,
+    val schoolService: Boolean,
 ): Identifiable<RouteId>, NavigationObject {
 
     companion object {
@@ -31,7 +32,8 @@ data class Route(
                 pb.designation,
                 RouteVisibility.fromPB(pb.routeVisibility),
                 pb.eventRoute == true,
-                pb.moreLink
+                pb.moreLink,
+                pb.schoolService == true
             )
         }
     }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Route.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Route.kt
@@ -14,7 +14,7 @@ data class Route(
     val routeVisibility: RouteVisibility,
     val eventRoute: Boolean,
     val moreLink: String?,
-    val schoolService: Boolean,
+    val schoolServiceOnly: Boolean,
 ): Identifiable<RouteId>, NavigationObject {
 
     companion object {
@@ -33,7 +33,7 @@ data class Route(
                 RouteVisibility.fromPB(pb.routeVisibility),
                 pb.eventRoute == true,
                 pb.moreLink,
-                pb.schoolService == true
+                pb.schoolServiceOnly == true
             )
         }
     }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Stop.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Stop.kt
@@ -15,7 +15,8 @@ data class Stop(
     val location: MapLocation,
     val accessibility: StopAccessibility,
     val visibility: StopVisibility,
-    val hasRealtime: Boolean
+    val hasRealtime: Boolean,
+    val schoolServiceOnly: Boolean,
 ): Serializable, Identifiable<StopId>, NavigationObject {
 
     companion object {
@@ -29,7 +30,8 @@ data class Stop(
                 MapLocation.fromPB(pb.location),
                 StopAccessibility.fromPB(pb.accessibility),
                 StopVisibility.fromPB(pb, pb.visibility),
-                pb.hasRealtime == true
+                pb.hasRealtime == true,
+                pb.schoolServiceOnly == true,
             )
         }
     }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/PreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/PreferencesRepository.kt
@@ -11,6 +11,7 @@ sealed interface Preference<T> {
     data object RequiresWheelchair: Preference<Boolean>
     data object RequiresBikes: Preference<Boolean>
     data object MaximumWalkingTime: Preference<Float>
+    data object ShowSchoolServices: Preference<Boolean>
     data object ShowAccessibilityIconsNavigation: Preference<Boolean>
     data object MetricUnits: Preference<Boolean>
     data object Use24HourUnits: Preference<Time24HSetting>
@@ -25,6 +26,7 @@ class PreferencesRepository(
         internal val REQUIRES_WHEELCHAIR_KEY = booleanPreferencesKey("ROUTER_REQUIRES_WHEELCHAIR")
         internal val ROUTER_REQUIRES_BIKE_KEY = booleanPreferencesKey("ROUTER_REQUIRES_BIKE")
         internal val ROUTER_MAXIMUM_WALKING_TIME_KEY = floatPreferencesKey("ROUTER_MAXIMUM_WALKING_TIME")
+        internal val SHOW_SCHOOL_SERVICES_KEY = booleanPreferencesKey("SHOW_SCHOOL_SERVICES_KEY")
         internal val ROUTER_SHOW_ACCESSIBILITY_ICONS = booleanPreferencesKey("ROUTER_SHOW_ACCESSIBILITY_ICONS")
         internal val DISPLAY_METRIC_UNITS_KEY = booleanPreferencesKey("DISPLAY_METRIC_UNITS")
         internal val TIME_24H_KEY = stringPreferencesKey("TIME_24H")
@@ -45,6 +47,12 @@ class PreferencesRepository(
     private val maximumWalkingTime: PreferencesUnit<Float> = SimplePreferencesUnit(
         ROUTER_MAXIMUM_WALKING_TIME_KEY,
         30f,
+        preferencesPersistence
+    )
+
+    private val showSchoolServices: PreferencesUnit<Boolean> = SimplePreferencesUnit(
+        SHOW_SCHOOL_SERVICES_KEY,
+        false,
         preferencesPersistence
     )
 
@@ -71,6 +79,7 @@ class PreferencesRepository(
     fun <T> preference(preference: Preference<T>): PreferencesUnit<T> = when (preference) {
         is Preference.MaximumWalkingTime -> maximumWalkingTime
         is Preference.MetricUnits -> metric
+        is Preference.ShowSchoolServices -> showSchoolServices
         is Preference.RequiresBikes -> requiresBikes
         is Preference.RequiresWheelchair -> requiresWheelchair
         is Preference.ShowAccessibilityIconsNavigation -> showAccessibilityIconsNavigation

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/PreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/PreferencesRepository.kt
@@ -3,6 +3,7 @@ package cl.emilym.sinatra.data.repository
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
+import cl.emilym.sinatra.FeatureFlag
 import cl.emilym.sinatra.data.models.Time24HSetting
 import cl.emilym.sinatra.data.persistence.PreferencesPersistence
 import org.koin.core.annotation.Factory
@@ -19,7 +20,8 @@ sealed interface Preference<T> {
 
 @Factory
 class PreferencesRepository(
-    preferencesPersistence: PreferencesPersistence
+    preferencesPersistence: PreferencesPersistence,
+    remoteConfigRepository: RemoteConfigRepository,
 ) {
 
     companion object {
@@ -50,10 +52,14 @@ class PreferencesRepository(
         preferencesPersistence
     )
 
-    private val showSchoolServices: PreferencesUnit<Boolean> = SimplePreferencesUnit(
-        SHOW_SCHOOL_SERVICES_KEY,
-        false,
-        preferencesPersistence
+    private val showSchoolServices: PreferencesUnit<Boolean> = FeatureFlaggedPreferencesUnit(
+        SimplePreferencesUnit(
+            SHOW_SCHOOL_SERVICES_KEY,
+            false,
+            preferencesPersistence
+        ),
+        remoteConfigRepository,
+        FeatureFlag.GLOBAL_ENABLE_SCHOOL_SERVICES
     )
 
     private val showAccessibilityIconsNavigation: PreferencesUnit<Boolean> = SimplePreferencesUnit(

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/RoutingPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/RoutingPreferencesRepository.kt
@@ -21,4 +21,8 @@ class RoutingPreferencesRepository(
         return preferencesRepository.preference(Preference.RequiresBikes).current()
     }
 
+    suspend fun schoolServiceAllowed(): Boolean {
+        return preferencesRepository.preference(Preference.ShowSchoolServices).current()
+    }
+
 }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/DisplayRoutesUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/DisplayRoutesUseCase.kt
@@ -4,21 +4,24 @@ import cl.emilym.sinatra.data.models.Cachable
 import cl.emilym.sinatra.data.models.Route
 import cl.emilym.sinatra.data.models.map
 import cl.emilym.sinatra.data.repository.RouteRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import org.koin.core.annotation.Factory
 
 @Factory
 class DisplayRoutesUseCase(
-    private val routeRepository: RouteRepository
+    private val getFilteredRoutesUseCase: GetFilteredRoutesUseCase
 ) {
 
-    suspend operator fun invoke(): Cachable<List<Route>> {
-        return routeRepository.routes().map {
-            it.filterAndSort()
+    operator fun invoke(): Flow<Cachable<List<Route>>> {
+        return getFilteredRoutesUseCase().map {
+            it.map { it.filterAndSort() }
         }
     }
 
 }
 
+@Deprecated("Use GetFilteredRoutesUseCase")
 internal fun List<Route>.filterAndSort(): List<Route> =
     filterNot { it.routeVisibility.hidden }.sortedWith(compareBy(
         { !it.eventRoute }, { it.designation == null }, { it.code.toIntOrNull() }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/GetFilteredRoutesUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/GetFilteredRoutesUseCase.kt
@@ -2,12 +2,10 @@ package cl.emilym.sinatra.domain
 
 import cl.emilym.sinatra.data.models.Cachable
 import cl.emilym.sinatra.data.models.Route
-import cl.emilym.sinatra.data.models.Stop
 import cl.emilym.sinatra.data.models.map
 import cl.emilym.sinatra.data.repository.Preference
 import cl.emilym.sinatra.data.repository.PreferencesRepository
 import cl.emilym.sinatra.data.repository.RouteRepository
-import cl.emilym.sinatra.data.repository.StopRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
@@ -31,7 +29,7 @@ class GetFilteredRoutesUseCase(
         return preferencesRepository.preference(Preference.ShowSchoolServices).flow.mapLatest {
             when (it) {
                 true -> routes
-                else -> routes.filter { !it.schoolService }
+                else -> routes.filter { !it.schoolServiceOnly }
             }.filterAndSort()
         }
     }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/GetFilteredRoutesUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/GetFilteredRoutesUseCase.kt
@@ -1,0 +1,39 @@
+package cl.emilym.sinatra.domain
+
+import cl.emilym.sinatra.data.models.Cachable
+import cl.emilym.sinatra.data.models.Route
+import cl.emilym.sinatra.data.models.Stop
+import cl.emilym.sinatra.data.models.map
+import cl.emilym.sinatra.data.repository.Preference
+import cl.emilym.sinatra.data.repository.PreferencesRepository
+import cl.emilym.sinatra.data.repository.RouteRepository
+import cl.emilym.sinatra.data.repository.StopRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.mapLatest
+import org.koin.core.annotation.Factory
+
+@Factory
+class GetFilteredRoutesUseCase(
+    private val routeRepository: RouteRepository,
+    private val preferencesRepository: PreferencesRepository
+) {
+
+    operator fun invoke(): Flow<Cachable<List<Route>>> = flow {
+        val routes = routeRepository.routes()
+        emitAll(
+            filterRoutes(routes.item).mapLatest { r -> routes.map { r } }
+        )
+    }
+
+    fun filterRoutes(routes: List<Route>): Flow<List<Route>> {
+        return preferencesRepository.preference(Preference.ShowSchoolServices).flow.mapLatest {
+            when (it) {
+                true -> routes
+                else -> routes.filter { !it.schoolService }
+            }.filterAndSort()
+        }
+    }
+
+}

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/GetFilteredStopsUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/GetFilteredStopsUseCase.kt
@@ -1,0 +1,33 @@
+package cl.emilym.sinatra.domain
+
+import cl.emilym.sinatra.data.models.Cachable
+import cl.emilym.sinatra.data.models.Stop
+import cl.emilym.sinatra.data.models.map
+import cl.emilym.sinatra.data.repository.Preference
+import cl.emilym.sinatra.data.repository.PreferencesRepository
+import cl.emilym.sinatra.data.repository.StopRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.mapLatest
+import org.koin.core.annotation.Factory
+
+@Factory
+class GetFilteredStopsUseCase(
+    private val stopRepository: StopRepository,
+    private val preferencesRepository: PreferencesRepository
+) {
+
+    operator fun invoke(): Flow<Cachable<List<Stop>>> = flow {
+        val stops = stopRepository.stops()
+        emitAll(
+            preferencesRepository.preference(Preference.ShowSchoolServices).flow.mapLatest {
+                when (it) {
+                    true -> stops
+                    else -> stops.map { it.filter { !it.schoolServiceOnly } }
+                }
+            }
+        )
+    }
+
+}

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/LastDepartureForStopUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/LastDepartureForStopUseCase.kt
@@ -7,10 +7,13 @@ import cl.emilym.sinatra.data.models.RouteId
 import cl.emilym.sinatra.data.models.StopId
 import cl.emilym.sinatra.data.models.StopTimetableTime
 import cl.emilym.sinatra.data.models.startOfDay
+import cl.emilym.sinatra.data.repository.Preference
+import cl.emilym.sinatra.data.repository.PreferencesRepository
 import cl.emilym.sinatra.data.repository.RemoteConfigRepository
 import cl.emilym.sinatra.data.repository.TransportMetadataRepository
 import io.github.aakira.napier.Napier.i
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
 import kotlinx.datetime.Clock
 import org.koin.core.annotation.Factory
@@ -28,7 +31,8 @@ class LastDepartureForStopUseCase(
     private val servicesAndTimesForStopUseCase: ServicesAndTimesForStopUseCase,
     private val metadataRepository: TransportMetadataRepository,
     private val remoteConfigRepository: RemoteConfigRepository,
-    private val clock: Clock
+    private val clock: Clock,
+    private val preferencesRepository: PreferencesRepository
 ) {
 
     operator fun invoke(
@@ -106,6 +110,11 @@ class LastDepartureForStopUseCase(
                     { it.heading }
                 ))
         )
+    }.combine(preferencesRepository.preference(Preference.ShowSchoolServices).flow) { last, school ->
+        when (school) {
+            true -> last
+            else -> last.filter { it.route?.schoolService == false }
+        }
     }
 
 }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/LastDepartureForStopUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/LastDepartureForStopUseCase.kt
@@ -11,13 +11,11 @@ import cl.emilym.sinatra.data.repository.Preference
 import cl.emilym.sinatra.data.repository.PreferencesRepository
 import cl.emilym.sinatra.data.repository.RemoteConfigRepository
 import cl.emilym.sinatra.data.repository.TransportMetadataRepository
-import io.github.aakira.napier.Napier.i
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
 import kotlinx.datetime.Clock
 import org.koin.core.annotation.Factory
-import kotlin.text.Typography.times
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 
@@ -113,7 +111,7 @@ class LastDepartureForStopUseCase(
     }.combine(preferencesRepository.preference(Preference.ShowSchoolServices).flow) { last, school ->
         when (school) {
             true -> last
-            else -> last.filter { it.route?.schoolService == false }
+            else -> last.filter { it.route?.schoolServiceOnly == false }
         }
     }
 

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/NearbyStopsUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/NearbyStopsUseCase.kt
@@ -6,6 +6,7 @@ import cl.emilym.sinatra.data.models.StopWithDistance
 import cl.emilym.sinatra.data.models.distance
 import cl.emilym.sinatra.data.repository.StopRepository
 import cl.emilym.sinatra.nullIfEmpty
+import kotlinx.coroutines.flow.first
 import org.koin.core.annotation.Factory
 
 const val NEAREST_STOP_RADIUS = 1.0
@@ -13,7 +14,7 @@ const val NEARBY_STOPS_LIMIT = 5
 
 @Factory
 class NearbyStopsUseCase(
-    private val stopRepository: StopRepository
+    private val getFilteredStopsUseCase: GetFilteredStopsUseCase
 ) {
 
     suspend operator fun invoke(
@@ -21,7 +22,7 @@ class NearbyStopsUseCase(
         radius: Double = NEAREST_STOP_RADIUS,
         limit: Int = NEARBY_STOPS_LIMIT
     ): List<StopWithDistance> {
-        val stops = stopRepository.stops().item
+        val stops = getFilteredStopsUseCase().first().item
         return stops.filter(location, radius, limit)
     }
 

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/PreferenceUnit.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/PreferenceUnit.kt
@@ -1,6 +1,7 @@
 package cl.emilym.sinatra.data.repository
 
 import androidx.datastore.preferences.core.Preferences
+import cl.emilym.sinatra.FeatureFlag
 import cl.emilym.sinatra.data.persistence.PreferencesPersistence
 import cl.emilym.sinatra.e
 import cl.emilym.sinatra.nullIfThrows
@@ -8,6 +9,7 @@ import io.github.aakira.napier.Napier
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.mapLatest
 
@@ -80,6 +82,33 @@ internal class WrapperMappedPreferencesUnit<I,O>(
     override suspend fun current(): O = fromPersistence(delegate.current())
 
     override suspend fun save(value: O) = delegate.save(toPersistence(value))
+}
+
+internal class FeatureFlaggedPreferencesUnit(
+    private val delegate: PreferencesUnit<Boolean>,
+    private val remoteConfigRepository: RemoteConfigRepository,
+    private val featureFlag: FeatureFlag
+): PreferencesUnit<Boolean> {
+    override val flow: Flow<Boolean>
+        get() = delegate.flow.mapLatest {
+            when (remoteConfigRepository.feature(featureFlag)) {
+                true -> it
+                else -> false
+            }
+        }
+    override val default: Boolean
+        get() = delegate.default
+
+    override suspend fun current(): Boolean {
+        return when (remoteConfigRepository.feature(featureFlag)) {
+            true -> delegate.current()
+            else -> false
+        }
+    }
+
+    override suspend fun save(value: Boolean) {
+        delegate.save(value)
+    }
 }
 
 fun <I,O> PreferencesUnit<I>.map(

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/RoutesVisitingStopUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/RoutesVisitingStopUseCase.kt
@@ -5,19 +5,24 @@ import cl.emilym.sinatra.data.models.Route
 import cl.emilym.sinatra.data.models.StopId
 import cl.emilym.sinatra.data.models.map
 import cl.emilym.sinatra.data.repository.StopRepository
+import kotlinx.coroutines.flow.Flow
 import org.koin.core.annotation.Factory
 
 @Factory
 class RoutesVisitingStopUseCase(
     private val stopRepository: StopRepository,
+    private val getFilteredRoutesUseCase: GetFilteredRoutesUseCase
 ) {
 
     suspend operator fun invoke(
         stopId: StopId
-    ): Cachable<List<Route>> {
-        return stopRepository.timetable(stopId).map {
-            it.times.mapNotNull { it.route }.distinctBy { it.id }.filterAndSort()
-        }
+    ): Flow<List<Route>> {
+        val timetable = stopRepository.timetable(stopId).item
+        return getFilteredRoutesUseCase.filterRoutes(
+            timetable.times
+                .mapNotNull { it.route }
+                .distinctBy { it.id }
+        )
     }
 
 }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/UpcomingRoutesForStopUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/UpcomingRoutesForStopUseCase.kt
@@ -8,6 +8,8 @@ import cl.emilym.sinatra.data.models.StopId
 import cl.emilym.sinatra.data.models.StopTimetableTime
 import cl.emilym.sinatra.data.models.map
 import cl.emilym.sinatra.data.models.startOfDay
+import cl.emilym.sinatra.data.repository.Preference
+import cl.emilym.sinatra.data.repository.PreferencesRepository
 import cl.emilym.sinatra.data.repository.RemoteConfigRepository
 import cl.emilym.sinatra.data.repository.TransportMetadataRepository
 import kotlinx.coroutines.Dispatchers
@@ -16,6 +18,7 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
@@ -26,6 +29,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.datetime.Clock
 import kotlinx.datetime.toLocalDateTime
 import org.koin.core.annotation.Factory
+import kotlin.text.Typography.times
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.minutes
 
@@ -35,6 +39,7 @@ class UpcomingRoutesForStopUseCase(
     private val servicesAndTimesForStopUseCase: ServicesAndTimesForStopUseCase,
     private val clock: Clock,
     private val metadataRepository: TransportMetadataRepository,
+    private val preferencesRepository: PreferencesRepository,
     private val remoteConfigRepository: RemoteConfigRepository
 ) {
 
@@ -119,6 +124,14 @@ class UpcomingRoutesForStopUseCase(
                 it
                     .sortedBy { it.arrivalTime }
                     .filter { it.departureTime > clock.now() }
+            }
+        }
+        .combine(preferencesRepository.preference(Preference.ShowSchoolServices).flow) { timetable, school ->
+            timetable.map {
+                when (school) {
+                    true -> it
+                    else -> it.filter { it.route?.schoolService == false }
+                }
             }
         }
     }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/UpcomingRoutesForStopUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/UpcomingRoutesForStopUseCase.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.isActive
 import kotlinx.datetime.Clock
 import kotlinx.datetime.toLocalDateTime
 import org.koin.core.annotation.Factory
-import kotlin.text.Typography.times
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.minutes
 
@@ -130,7 +129,7 @@ class UpcomingRoutesForStopUseCase(
             timetable.map {
                 when (school) {
                     true -> it
-                    else -> it.filter { it.route?.schoolService == false }
+                    else -> it.filter { it.route?.schoolServiceOnly == false }
                 }
             }
         }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/navigation/CalculateJourneyUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/navigation/CalculateJourneyUseCase.kt
@@ -63,6 +63,7 @@ class CalculateJourneyUseCase(
     private lateinit var arrivalLocation: JourneyLocation
     private var onlyWheelchair: Boolean = false
     private var onlyBikes: Boolean = false
+    private var allowSchoolService: Boolean = false
 
     suspend operator fun invoke(
         departureLocation: JourneyLocation,
@@ -78,6 +79,7 @@ class CalculateJourneyUseCase(
                 this@CalculateJourneyUseCase.arrivalLocation = arrivalLocation
                 this@CalculateJourneyUseCase.onlyBikes = onlyBikes
                 this@CalculateJourneyUseCase.onlyWheelchair = onlyWheelchair
+                this@CalculateJourneyUseCase.allowSchoolService = routingPreferencesRepository.schoolServiceAllowed()
 
                 val now = anchorTime.time
                 stops = stopRepository.stops()
@@ -166,7 +168,8 @@ class CalculateJourneyUseCase(
     ): Journey? {
         val prefs = RouterPrefs(
             wheelchairAccessible = onlyWheelchair,
-            bikesAllowed = onlyBikes
+            bikesAllowed = onlyBikes,
+            schoolAllowed = allowSchoolService
         )
 
         val raptor = routerFactory(

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/search/RouteTypeSearcher.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/search/RouteTypeSearcher.kt
@@ -2,11 +2,13 @@ package cl.emilym.sinatra.domain.search
 
 import cl.emilym.sinatra.data.models.Route
 import cl.emilym.sinatra.data.repository.RouteRepository
+import cl.emilym.sinatra.domain.GetFilteredRoutesUseCase
+import kotlinx.coroutines.flow.first
 import org.koin.core.annotation.Factory
 
 @Factory
 class RouteTypeSearcher(
-    private val routeRepository: RouteRepository
+    private val getFilteredRoutesUseCase: GetFilteredRoutesUseCase
 ): LocalTypeSearcher<Route>() {
 
     override fun fields(t: Route) = listOf(t.name, t.displayCode)
@@ -21,7 +23,7 @@ class RouteTypeSearcher(
     }
 
     override suspend fun load(): List<Route> {
-        return routeRepository.routes().item
+        return getFilteredRoutesUseCase().first().item
     }
 
     override fun wrap(item: Route): SearchResult {

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/search/StopTypeSearcher.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/search/StopTypeSearcher.kt
@@ -2,11 +2,13 @@ package cl.emilym.sinatra.domain.search
 
 import cl.emilym.sinatra.data.models.Stop
 import cl.emilym.sinatra.data.repository.StopRepository
+import cl.emilym.sinatra.domain.GetFilteredStopsUseCase
+import kotlinx.coroutines.flow.first
 import org.koin.core.annotation.Factory
 
 @Factory
 class StopTypeSearcher(
-    private val stopRepository: StopRepository
+    private val getFilteredStopsUseCase: GetFilteredStopsUseCase
 ): LocalTypeSearcher<Stop>() {
 
     override fun fields(t: Stop) = listOf(t.id, t.name)
@@ -20,7 +22,7 @@ class StopTypeSearcher(
     }
 
     override suspend fun load(): List<Stop> {
-        return stopRepository.stops().item
+        return getFilteredStopsUseCase().first().item
     }
 
     override fun wrap(item: Stop): SearchResult {

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/room/entities/RouteEntity.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/room/entities/RouteEntity.kt
@@ -4,7 +4,6 @@ import androidx.room.ColumnInfo
 import androidx.room.Embedded
 import androidx.room.Entity
 import androidx.room.ForeignKey
-import androidx.room.Index
 import androidx.room.PrimaryKey
 import androidx.room.Relation
 import cl.emilym.sinatra.data.models.ColorPair
@@ -51,7 +50,7 @@ data class RouteEntity(
     @ColumnInfo(defaultValue = "0")
     val hasRealtime: Boolean,
     @ColumnInfo(defaultValue = "0")
-    val schoolService: Boolean
+    val schoolServiceOnly: Boolean
 ) {
 
     fun toModel(): Route {
@@ -75,7 +74,7 @@ data class RouteEntity(
             ),
             eventRoute,
             moreLink,
-            schoolService
+            schoolServiceOnly
         )
     }
 
@@ -98,7 +97,7 @@ data class RouteEntity(
                 m.eventRoute,
                 m.moreLink,
                 m.hasRealtime,
-                m.schoolService
+                m.schoolServiceOnly
             )
         }
     }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/room/entities/RouteEntity.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/room/entities/RouteEntity.kt
@@ -49,7 +49,9 @@ data class RouteEntity(
     @ColumnInfo(defaultValue = "NULL")
     val moreLink: String?,
     @ColumnInfo(defaultValue = "0")
-    val hasRealtime: Boolean
+    val hasRealtime: Boolean,
+    @ColumnInfo(defaultValue = "0")
+    val schoolService: Boolean
 ) {
 
     fun toModel(): Route {
@@ -72,7 +74,8 @@ data class RouteEntity(
                 showOnBrowse
             ),
             eventRoute,
-            moreLink
+            moreLink,
+            schoolService
         )
     }
 
@@ -94,7 +97,8 @@ data class RouteEntity(
                 m.routeVisibility.showOnBrowse,
                 m.eventRoute,
                 m.moreLink,
-                m.hasRealtime
+                m.hasRealtime,
+                m.schoolService
             )
         }
     }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/room/entities/StopEntity.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/room/entities/StopEntity.kt
@@ -29,7 +29,9 @@ class StopEntity(
     @ColumnInfo(defaultValue = "NULL")
     val searchWeight: Double? = StopVisibility.SEARCH_WEIGHT_DEFAULT,
     @ColumnInfo(defaultValue = "0")
-    val hasRealtime: Boolean
+    val hasRealtime: Boolean,
+    @ColumnInfo(defaultValue = "0")
+    val schoolServiceOnly: Boolean,
 ) {
 
     fun toModel(): Stop {
@@ -48,7 +50,8 @@ class StopEntity(
                 showChildren,
                 searchWeight,
             ),
-            hasRealtime
+            hasRealtime,
+            schoolServiceOnly
         )
     }
 
@@ -66,7 +69,8 @@ class StopEntity(
                 stop.visibility.visibleZoomedIn,
                 stop.visibility.showChildren,
                 stop.visibility.searchWeight,
-                stop.hasRealtime
+                stop.hasRealtime,
+                stop.schoolServiceOnly
             )
         }
     }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/router/Router.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/router/Router.kt
@@ -29,12 +29,14 @@ data class RaptorConfig(
 
 data class RouterPrefs(
     val wheelchairAccessible: Boolean,
-    val bikesAllowed: Boolean
+    val bikesAllowed: Boolean,
+    val schoolAllowed: Boolean
 )
 
 internal val DEFAULT_ROUTER_PREFS = RouterPrefs(
     wheelchairAccessible = false,
-    bikesAllowed = false
+    bikesAllowed = false,
+    schoolAllowed = false,
 )
 
 abstract class Router {
@@ -264,6 +266,7 @@ abstract class Router {
         val edges = node.edges
 
         return edges.flatMap {
+            if (it.schoolOnly && !prefs.schoolAllowed) return@flatMap emptyList()
             when (it.type) {
                 EdgeType.TO_ROUTE_NODE -> listOf(
                     NodeCost(it.connectedNodeIndex.toInt(), 0L, 0L, it, null)

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/router/data/ByteNetworkGraph.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/router/data/ByteNetworkGraph.kt
@@ -311,6 +311,7 @@ class ByteNetworkGraphEdge(
 
     override val wheelchairAccessible: Boolean get() = (flags and 0b100) == 0b100.toByte()
     override val bikesAllowed: Boolean get() = (flags and 0b1000) == 0b1000.toByte()
+    override val schoolOnly: Boolean get() = (flags and 0b10000) == 0b10000.toByte()
 
     override fun toString(): String {
         return "NetworkGraphEdge(connectedNodeIndex=$connectedNodeIndex, cost=$cost, departureTime=$departureTime, availableServices=$availableServices, type=$type, wheelchairAccessible=$wheelchairAccessible, bikesAllowed=$bikesAllowed)"

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/router/data/NetworkGraph.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/router/data/NetworkGraph.kt
@@ -92,5 +92,6 @@ interface NetworkGraphEdge {
     val type: EdgeType
     val wheelchairAccessible: Boolean
     val bikesAllowed: Boolean
+    val schoolOnly: Boolean
 }
 

--- a/shared/src/commonMain/proto/gtfs-api.proto
+++ b/shared/src/commonMain/proto/gtfs-api.proto
@@ -129,7 +129,7 @@ message Route {
   optional string description = 13;
   optional string moreLink = 14;
   optional RouteVisibility routeVisibility = 9;
-  optional bool schoolService = 15;
+  optional bool schoolServiceOnly = 15;
 }
 
 message RouteVisibility {

--- a/shared/src/commonMain/proto/gtfs-api.proto
+++ b/shared/src/commonMain/proto/gtfs-api.proto
@@ -128,6 +128,7 @@ message Route {
   optional string description = 13;
   optional string moreLink = 14;
   optional RouteVisibility routeVisibility = 9;
+  optional bool schoolService = 15;
 }
 
 message RouteVisibility {

--- a/shared/src/commonMain/proto/gtfs-api.proto
+++ b/shared/src/commonMain/proto/gtfs-api.proto
@@ -92,6 +92,7 @@ message Stop {
   required StopAccessibility accessibility = 4;
   optional StopVisibility visibility = 6;
   optional bool hasRealtime = 8;
+  optional bool schoolServiceOnly = 9;
 }
 
 message StopAccessibility {

--- a/ui/src/commonMain/composeResources/values-zh/strings.xml
+++ b/ui/src/commonMain/composeResources/values-zh/strings.xml
@@ -42,6 +42,10 @@
 
   <string name="preferences_setting_bikes_subtitle">配备自行车架的路线。</string>
 
+  <string name="preferences_setting_school_service">显示校车服务</string>
+
+  <string name="preferences_setting_school_service_subtitle">显示学校交通选项，并在路线规划中包含校车。</string>
+
   <string name="preferences_setting_show_accessibility_icons_navigation">显示无障碍信息</string>
 
   <string name="preferences_setting_show_accessibility_icons_navigation_subtitle">显示路线是否适合骑行或轮椅通行。</string>

--- a/ui/src/commonMain/composeResources/values/strings.xml
+++ b/ui/src/commonMain/composeResources/values/strings.xml
@@ -24,6 +24,8 @@
     <string name="preferences_setting_wheelchair_subtitle">Default to calculating routes with wheelchair accessibility when navigating.</string>
     <string name="preferences_setting_bikes">Bike Rack Required</string>
     <string name="preferences_setting_bikes_subtitle">Require routes to have bike racks available.</string>
+    <string name="preferences_setting_school_service">Show School Services</string>
+    <string name="preferences_setting_school_service_subtitle">Show school transportation options and include school buses when routing.</string>
     <string name="preferences_setting_show_accessibility_icons_navigation">Highlight Accessibility</string>
     <string name="preferences_setting_show_accessibility_icons_navigation_subtitle">Show whether a journey is bike or wheelchair accessible.</string>
     <string name="preferences_setting_max_walking">Maximum walking time</string>

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/MapSearchViewModel.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/MapSearchViewModel.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import cafe.adriel.voyager.core.model.screenModelScope
 import cl.emilym.compose.requeststate.RequestState
+import cl.emilym.compose.requeststate.flatRequestStateFlow
 import cl.emilym.compose.requeststate.handle
 import cl.emilym.sinatra.data.models.Alert
 import cl.emilym.sinatra.data.models.MapLocation
@@ -17,6 +18,7 @@ import cl.emilym.sinatra.data.repository.AlertRepository
 import cl.emilym.sinatra.data.repository.ContentRepository
 import cl.emilym.sinatra.data.repository.RecentVisitRepository
 import cl.emilym.sinatra.data.repository.StopRepository
+import cl.emilym.sinatra.domain.GetFilteredStopsUseCase
 import cl.emilym.sinatra.domain.NEARBY_STOPS_LIMIT
 import cl.emilym.sinatra.domain.NEAREST_STOP_RADIUS
 import cl.emilym.sinatra.domain.NearbyStopsUseCase
@@ -28,6 +30,7 @@ import cl.emilym.sinatra.ui.presentation.screens.search.SearchScreenViewModel
 import cl.emilym.sinatra.ui.presentation.screens.search.searchHandler
 import cl.emilym.sinatra.ui.widgets.SinatraScreenModel
 import cl.emilym.sinatra.ui.widgets.createRequestStateFlowFlow
+import cl.emilym.sinatra.ui.widgets.defaultConfig
 import cl.emilym.sinatra.ui.widgets.handleFlowProperly
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
@@ -49,7 +52,7 @@ sealed interface MapSearchState {
 
 @Factory
 class MapSearchViewModel(
-    private val stopRepository: StopRepository,
+    private val getFilteredStopsUseCase: GetFilteredStopsUseCase,
     private val routeStopSearchUseCase: RouteStopSearchUseCase,
     private val recentVisitRepository: RecentVisitRepository,
     private val alertRepository: AlertRepository,
@@ -75,13 +78,15 @@ class MapSearchViewModel(
         }
     }.state(RequestState.Initial())
 
+    private val _stops = flatRequestStateFlow(defaultConfig) { getFilteredStopsUseCase().mapLatest { it.item } }
+    val stops = _stops.state()
+
     private val lastLocation = MutableStateFlow<MapLocation?>(null)
-    val stops = MutableStateFlow<RequestState<List<Stop>>>(RequestState.Initial())
     val showCurrentLocation = MutableStateFlow(false)
     val zoomToLocation = MutableSharedFlow<Unit>()
     private var hasZoomedToLocation = false
 
-    override val nearbyStops = stops.combine(lastLocation) { stops, lastLocation ->
+    override val nearbyStops = _stops.combine(lastLocation) { stops, lastLocation ->
         if (stops !is RequestState.Success || lastLocation == null) return@combine null
         val stops = stops.value.nullIfEmpty() ?: return@combine null
         with(nearbyStopsUseCase) { stops.filter(lastLocation).nullIfEmpty() }
@@ -101,9 +106,7 @@ class MapSearchViewModel(
 
     fun retry() {
         screenModelScope.launch {
-            stops.handle {
-                stopRepository.stops().item
-            }
+            _stops.retry()
         }
     }
 

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/BrowseViewModel.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/BrowseViewModel.kt
@@ -77,7 +77,7 @@ class BrowseViewModel(
     private val serviceAlertRepository: ServiceAlertRepository
 ): SinatraScreenModel {
 
-    private val _routes = requestStateFlow(defaultConfig) { displayRoutesUseCase().item }
+    private val _routes = flatRequestStateFlow(defaultConfig) { displayRoutesUseCase().mapLatest { it.item } }
     val routes = _routes.state(RequestState.Initial())
 
     private val lastLocation = MutableStateFlow<MapLocation?>(null)

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/stop/StopDetailViewModel.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/stop/StopDetailViewModel.kt
@@ -130,8 +130,8 @@ class StopDetailViewModel(
         upcoming.map { it.filter { routeId.isEmpty() || routeId.contains(it.routeId) } }
     }.state()
 
-    private val _routes = stopId.filterNotNull().requestStateFlow { stopId ->
-        routesForStopUseCase(stopId).item
+    private val _routes = stopId.filterNotNull().flatRequestStateFlow { stopId ->
+        routesForStopUseCase(stopId)
     }
     private val routesState = _routes.state()
 

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/preferences/RoutingPreferencesScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/preferences/RoutingPreferencesScreen.kt
@@ -42,7 +42,7 @@ class RoutingPreferencesScreen: PreferencesScreen() {
     @Composable
     override fun ColumnScope.Preferences() {
         val showAccessibilitySettings = !FeatureFlag.GLOBAL_HIDE_TRANSPORT_ACCESSIBILITY.value()
-        val showSchoolServiceSettings = !FeatureFlag.GLOBAL_ENABLE_SCHOOL_SERVICES.value()
+        val showSchoolServiceSettings = FeatureFlag.GLOBAL_ENABLE_SCHOOL_SERVICES.value()
 
         if (showAccessibilitySettings) {
             HorizontalLockup(

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/preferences/RoutingPreferencesScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/preferences/RoutingPreferencesScreen.kt
@@ -27,6 +27,8 @@ import sinatra.ui.generated.resources.preferences_setting_max_walking
 import sinatra.ui.generated.resources.preferences_setting_wheelchair
 import sinatra.ui.generated.resources.preferences_setting_wheelchair_subtitle
 import sinatra.ui.generated.resources.preferences_routing_title
+import sinatra.ui.generated.resources.preferences_setting_school_service
+import sinatra.ui.generated.resources.preferences_setting_school_service_subtitle
 import sinatra.ui.generated.resources.preferences_setting_show_accessibility_icons_navigation
 import sinatra.ui.generated.resources.preferences_setting_show_accessibility_icons_navigation_subtitle
 import kotlin.time.Duration.Companion.minutes
@@ -40,6 +42,8 @@ class RoutingPreferencesScreen: PreferencesScreen() {
     @Composable
     override fun ColumnScope.Preferences() {
         val showAccessibilitySettings = !FeatureFlag.GLOBAL_HIDE_TRANSPORT_ACCESSIBILITY.value()
+        val showSchoolServiceSettings = !FeatureFlag.GLOBAL_ENABLE_SCHOOL_SERVICES.value()
+
         if (showAccessibilitySettings) {
             HorizontalLockup(
                 stringResource(Res.string.preferences_setting_wheelchair),
@@ -56,7 +60,19 @@ class RoutingPreferencesScreen: PreferencesScreen() {
             ) {
                 PreferencesCheckbox(Preference.RequiresBikes)
             }
+        }
 
+        if (showSchoolServiceSettings) {
+            HorizontalLockup(
+                stringResource(Res.string.preferences_setting_school_service),
+                stringResource(Res.string.preferences_setting_school_service_subtitle),
+                Modifier.fillMaxWidth()
+            ) {
+                PreferencesCheckbox(Preference.RequiresWheelchair)
+            }
+        }
+
+        if (showAccessibilitySettings) {
             HorizontalLockup(
                 stringResource(Res.string.preferences_setting_show_accessibility_icons_navigation),
                 stringResource(Res.string.preferences_setting_show_accessibility_icons_navigation_subtitle),
@@ -65,6 +81,7 @@ class RoutingPreferencesScreen: PreferencesScreen() {
                 PreferencesCheckbox(Preference.ShowAccessibilityIconsNavigation)
             }
         }
+
 
         VerticalLockup(
             stringResource(Res.string.preferences_setting_max_walking),

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/SearchWidget.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/SearchWidget.kt
@@ -43,6 +43,7 @@ import cl.emilym.sinatra.data.models.Stop
 import cl.emilym.sinatra.data.models.StopWithDistance
 import cl.emilym.sinatra.data.repository.RecentVisitRepository
 import cl.emilym.sinatra.data.repository.StopRepository
+import cl.emilym.sinatra.domain.GetFilteredStopsUseCase
 import cl.emilym.sinatra.domain.NearbyStopsUseCase
 import cl.emilym.sinatra.domain.search.RouteStopSearchUseCase
 import cl.emilym.sinatra.domain.search.SearchResult
@@ -73,11 +74,11 @@ internal class DefaultSearchScreenViewModel(
     private val routeStopSearchUseCase: RouteStopSearchUseCase,
     private val recentVisitRepository: RecentVisitRepository,
     private val nearbyStopsUseCase: NearbyStopsUseCase,
-    private val stopRepository: StopRepository
+    private val getFilteredStopsUseCase: GetFilteredStopsUseCase
 ): SinatraScreenModel, SearchScreenViewModel {
 
     val lastLocation = MutableStateFlow<MapLocation?>(null)
-    private val stops = requestStateFlow(defaultConfig) { stopRepository.stops() }
+    private val stops = flatRequestStateFlow(defaultConfig) { getFilteredStopsUseCase() }
 
     override var query by mutableStateOf("")
     private val searchTypes = MutableStateFlow<List<SearchType>>(listOf())


### PR DESCRIPTION
This change adds the ability to filter routes and stops based on whether they are designated as "school service only".

- Introduces a new `schoolServiceOnly` field to routes and stops.
- Adds a user preference to show or hide school services.
- Updates the UI and data layers to respect this preference.
- Improves journey calculations to exclude school services when the preference is disabled.