### PR TITLE
Fix iOS build

### DIFF
--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/room/dao/FavouriteDao.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/room/dao/FavouriteDao.kt
@@ -68,7 +68,7 @@ abstract class FavouriteDao {
     abstract fun getPlace(placeId: String): Flow<FavouriteEntity?>
 
     @Query("SELECT `order` FROM favouriteEntity WHERE id = :id")
-    protected abstract fun currentOrder(id: Long): Int
+    protected abstract suspend fun currentOrder(id: Long): Int
 
     @Query("UPDATE favouriteEntity SET `order` = `order` - 1 WHERE `order` > :oldOrder AND `order` <= :newOrder AND `order` >= 0")
     protected abstract suspend fun moveOrderDown(newOrder: Int, oldOrder: Int)

--- a/ui/src/nativeMain/kotlin/cl/emilym/sinatra/ui/widgets/LifecycleExt.native.kt
+++ b/ui/src/nativeMain/kotlin/cl/emilym/sinatra/ui/widgets/LifecycleExt.native.kt
@@ -2,10 +2,13 @@ package cl.emilym.sinatra.ui.widgets
 
 import androidx.lifecycle.Lifecycle
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.coroutineScope
 
 actual suspend fun Lifecycle.repeatOnLifecycleCompat(
     state: Lifecycle.State,
     block: suspend CoroutineScope.() -> Unit
 ) {
-    block()
+    coroutineScope {
+        block()
+    }
 }


### PR DESCRIPTION
Updates the `currentOrder` function in the favourite dao to be a suspend function and correctly calls block in repeatOnLifecycleCompat with coroutineScope.
