### PR TITLE
Fix crash when viewing route detail and stops failed to load

### DIFF
--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/route/RouteDetailScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/route/RouteDetailScreen.kt
@@ -230,8 +230,8 @@ class RouteDetailScreen(
         LaunchedEffect(info?.stops) {
             if (FeatureFlag.ROUTE_DETAIL_PREVENT_ZOOM_WHEN_HAVE_SOURCE_STOP.immediate && stopId != null)
                 return@LaunchedEffect
-            info?.stops?.let {
-                mapControl.zoomToArea(info.stops.mapNotNull { it.stop?.location }.bounds(), zoomPadding)
+            info?.stops?.mapNotNull { it.stop?.location }?.nullIfEmpty()?.let {
+                mapControl.zoomToArea(it.bounds(), zoomPadding)
             }
         }
 


### PR DESCRIPTION
A crash occurs if a route is viewed and the stops failed to load. This corrects that (although that error state is still bad)