### PR TITLE
Add a clear cache button

### DIFF
--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/FeatureFlags.kt
@@ -48,7 +48,8 @@ enum class FeatureFlag(
     GLOBAL_HIDE_TRANSPORT_ACCESSIBILITY(false),
     UPCOMING_ROUTES_INCLUDE_NEXT_DAY(true),
     REALTIME_USE_GLOBAL(true),
-    GLOBAL_ENABLE_SCHOOL_SERVICES(false);
+    GLOBAL_ENABLE_SCHOOL_SERVICES(false),
+    SETTINGS_CLEAR_CACHE(true);
 
     val immediate by EnumFeatureFlagDelegate(this)
 }

--- a/ui/src/commonMain/composeResources/values-zh/strings.xml
+++ b/ui/src/commonMain/composeResources/values-zh/strings.xml
@@ -34,6 +34,8 @@
 
   <string name="preferences_setting_clear_recent_history">清除查看历史记录</string>
 
+  <string name="preferences_setting_clear_cache">清除缓存</string>
+
   <string name="preferences_setting_wheelchair">需要轮椅</string>
 
   <string name="preferences_setting_wheelchair_subtitle">导航时默认规划适合轮椅通行的路线。</string>

--- a/ui/src/commonMain/composeResources/values/strings.xml
+++ b/ui/src/commonMain/composeResources/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="preferences_location_title">Location Permissions</string>
     <string name="preferences_units_title">Units</string>
     <string name="preferences_setting_clear_recent_history">Clear view history</string>
+    <string name="preferences_setting_clear_cache">Clear cache</string>
     <string name="preferences_setting_wheelchair">Wheelchair Required</string>
     <string name="preferences_setting_wheelchair_subtitle">Default to calculating routes with wheelchair accessibility when navigating.</string>
     <string name="preferences_setting_bikes">Bike Rack Required</string>

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/preferences/PreferencesScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/preferences/PreferencesScreen.kt
@@ -26,6 +26,7 @@ import cl.emilym.sinatra.nullIfEmpty
 import cl.emilym.sinatra.ui.widgets.ContentLinkWidget
 import cl.emilym.sinatra.ui.widgets.NavigatorBackButton
 import org.koin.compose.koinInject
+import kotlin.text.iterator
 
 abstract class PreferencesScreen: Screen {
     @get:Composable
@@ -52,9 +53,6 @@ abstract class PreferencesScreen: Screen {
                         .verticalScroll(rememberScrollState())
                         .padding(innerPadding),
                 ) {
-                    val preferencesRepository = koinInject<PreferencesRepository>()
-                    val scope = rememberCoroutineScope()
-
                     Column(
                         Modifier
                             .fillMaxWidth()
@@ -63,16 +61,7 @@ abstract class PreferencesScreen: Screen {
                     ) {
                         Preferences()
                     }
-                    options().nullIfEmpty()?.let {
-                        Column(
-                            Modifier.fillMaxWidth(),
-                            verticalArrangement = Arrangement.spacedBy(2.dp)
-                        ) {
-                            for (link in it) {
-                                ContentLinkWidget(link, Modifier.fillMaxWidth())
-                            }
-                        }
-                    }
+                    BottomContent()
                 }
             }
         }
@@ -82,6 +71,5 @@ abstract class PreferencesScreen: Screen {
     abstract fun ColumnScope.Preferences()
 
     @Composable
-    open fun options(): List<ContentLink> { return emptyList() }
-
+    open fun ColumnScope.BottomContent() {}
 }

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/preferences/RootPreferencesScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/preferences/RootPreferencesScreen.kt
@@ -12,6 +12,7 @@ import cafe.adriel.voyager.core.model.screenModelScope
 import cafe.adriel.voyager.core.screen.ScreenKey
 import cafe.adriel.voyager.koin.koinScreenModel
 import cl.emilym.compose.units.rdp
+import cl.emilym.sinatra.FeatureFlag
 import cl.emilym.sinatra.data.models.ContentLink
 import cl.emilym.sinatra.data.models.DisclosureType
 import cl.emilym.sinatra.data.repository.ContentRepository
@@ -22,6 +23,7 @@ import cl.emilym.sinatra.ui.widgets.ContentLinkColumn
 import cl.emilym.sinatra.ui.widgets.ContentLinkWidget
 import cl.emilym.sinatra.ui.widgets.SinatraScreenModel
 import cl.emilym.sinatra.ui.widgets.platformContext
+import cl.emilym.sinatra.ui.widgets.value
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import org.koin.core.annotation.Factory
@@ -92,7 +94,7 @@ class RootPreferencesScreen: PreferencesScreen() {
             Spacer(Modifier.height(1.rdp))
 
             ContentLinkColumn(
-                listOf(
+                listOfNotNull(
                     ContentLink.Custom(
                         stringResource(Res.string.preferences_setting_clear_recent_history),
                         DisclosureType.NONE,
@@ -100,12 +102,16 @@ class RootPreferencesScreen: PreferencesScreen() {
                     ) {
                         viewModel.clearVisitHistory()
                     },
-                    ContentLink.Custom(
-                        stringResource(Res.string.preferences_setting_clear_cache),
-                        DisclosureType.NONE,
-                        0,
-                    ) {
-                        viewModel.clearCache()
+                    if (FeatureFlag.SETTINGS_CLEAR_CACHE.value()) {
+                        ContentLink.Custom(
+                            stringResource(Res.string.preferences_setting_clear_cache),
+                            DisclosureType.NONE,
+                            0,
+                        ) {
+                            viewModel.clearCache()
+                        }
+                    } else {
+                        null
                     }
                 )
             )

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/preferences/RootPreferencesScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/preferences/RootPreferencesScreen.kt
@@ -1,15 +1,25 @@
 package cl.emilym.sinatra.ui.presentation.screens.preferences
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import cafe.adriel.voyager.core.model.screenModelScope
 import cafe.adriel.voyager.core.screen.ScreenKey
 import cafe.adriel.voyager.koin.koinScreenModel
+import cl.emilym.compose.units.rdp
 import cl.emilym.sinatra.data.models.ContentLink
 import cl.emilym.sinatra.data.models.DisclosureType
 import cl.emilym.sinatra.data.repository.ContentRepository
 import cl.emilym.sinatra.data.repository.PlatformContext
 import cl.emilym.sinatra.data.repository.RecentVisitRepository
+import cl.emilym.sinatra.domain.CacheInvalidationUseCase
+import cl.emilym.sinatra.ui.widgets.ContentLinkColumn
+import cl.emilym.sinatra.ui.widgets.ContentLinkWidget
 import cl.emilym.sinatra.ui.widgets.SinatraScreenModel
 import cl.emilym.sinatra.ui.widgets.platformContext
 import kotlinx.coroutines.launch
@@ -19,17 +29,25 @@ import sinatra.ui.generated.resources.Res
 import sinatra.ui.generated.resources.preferences_location_title
 import sinatra.ui.generated.resources.preferences_root_title
 import sinatra.ui.generated.resources.preferences_routing_title
+import sinatra.ui.generated.resources.preferences_setting_clear_cache
 import sinatra.ui.generated.resources.preferences_units_title
 import sinatra.ui.generated.resources.preferences_setting_clear_recent_history
 
 @Factory
 class RootPreferencesViewModel(
-    private val recentVisitRepository: RecentVisitRepository
+    private val recentVisitRepository: RecentVisitRepository,
+    private val cacheInvalidationUseCase: CacheInvalidationUseCase
 ): SinatraScreenModel {
 
     fun clearVisitHistory() {
         screenModelScope.launch {
             recentVisitRepository.clear()
+        }
+    }
+
+    fun clearCache() {
+        screenModelScope.launch {
+            cacheInvalidationUseCase()
         }
     }
 
@@ -46,34 +64,52 @@ class RootPreferencesScreen: PreferencesScreen() {
     override fun ColumnScope.Preferences() {}
 
     @Composable
-    override fun options(): List<ContentLink> {
+    override fun ColumnScope.BottomContent() {
         val context = platformContext()
         val viewModel = koinScreenModel<RootPreferencesViewModel>()
 
-        return listOf(
-            ContentLink.native(
-                stringResource(Res.string.preferences_routing_title),
-                ContentRepository.NATIVE_PREFERENCES_ROUTING_ID
-            ),
-            ContentLink.native(
-                stringResource(Res.string.preferences_units_title),
-                ContentRepository.NATIVE_PREFERENCES_UNITS_ID
-            ),
-            ContentLink.Custom(
-                stringResource(Res.string.preferences_location_title),
-                DisclosureType.EXTERNAL,
-                0,
-            ) {
-                openLocationSettings(context)
-            },
-            ContentLink.Custom(
-                stringResource(Res.string.preferences_setting_clear_recent_history),
-                DisclosureType.NONE,
-                0,
-            ) {
-                viewModel.clearVisitHistory()
-            }
-        )
+        Column {
+            ContentLinkColumn(
+                listOf(
+                    ContentLink.native(
+                        stringResource(Res.string.preferences_routing_title),
+                        ContentRepository.NATIVE_PREFERENCES_ROUTING_ID
+                    ),
+                    ContentLink.native(
+                        stringResource(Res.string.preferences_units_title),
+                        ContentRepository.NATIVE_PREFERENCES_UNITS_ID
+                    ),
+                    ContentLink.Custom(
+                        stringResource(Res.string.preferences_location_title),
+                        DisclosureType.EXTERNAL,
+                        0,
+                    ) {
+                        openLocationSettings(context)
+                    }
+                )
+            )
+
+            Spacer(Modifier.height(1.rdp))
+
+            ContentLinkColumn(
+                listOf(
+                    ContentLink.Custom(
+                        stringResource(Res.string.preferences_setting_clear_recent_history),
+                        DisclosureType.NONE,
+                        0,
+                    ) {
+                        viewModel.clearVisitHistory()
+                    },
+                    ContentLink.Custom(
+                        stringResource(Res.string.preferences_setting_clear_cache),
+                        DisclosureType.NONE,
+                        0,
+                    ) {
+                        viewModel.clearCache()
+                    }
+                )
+            )
+        }
     }
 
 }

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/preferences/RootPreferencesScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/preferences/RootPreferencesScreen.kt
@@ -1,10 +1,8 @@
 package cl.emilym.sinatra.ui.presentation.screens.preferences
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -18,9 +16,8 @@ import cl.emilym.sinatra.data.models.DisclosureType
 import cl.emilym.sinatra.data.repository.ContentRepository
 import cl.emilym.sinatra.data.repository.PlatformContext
 import cl.emilym.sinatra.data.repository.RecentVisitRepository
-import cl.emilym.sinatra.domain.CacheInvalidationUseCase
+import cl.emilym.sinatra.data.repository.ShaRepository
 import cl.emilym.sinatra.ui.widgets.ContentLinkColumn
-import cl.emilym.sinatra.ui.widgets.ContentLinkWidget
 import cl.emilym.sinatra.ui.widgets.SinatraScreenModel
 import cl.emilym.sinatra.ui.widgets.platformContext
 import cl.emilym.sinatra.ui.widgets.value
@@ -32,13 +29,13 @@ import sinatra.ui.generated.resources.preferences_location_title
 import sinatra.ui.generated.resources.preferences_root_title
 import sinatra.ui.generated.resources.preferences_routing_title
 import sinatra.ui.generated.resources.preferences_setting_clear_cache
-import sinatra.ui.generated.resources.preferences_units_title
 import sinatra.ui.generated.resources.preferences_setting_clear_recent_history
+import sinatra.ui.generated.resources.preferences_units_title
 
 @Factory
 class RootPreferencesViewModel(
     private val recentVisitRepository: RecentVisitRepository,
-    private val cacheInvalidationUseCase: CacheInvalidationUseCase
+    private val shaRepository: ShaRepository
 ): SinatraScreenModel {
 
     fun clearVisitHistory() {
@@ -49,7 +46,7 @@ class RootPreferencesViewModel(
 
     fun clearCache() {
         screenModelScope.launch {
-            cacheInvalidationUseCase()
+            shaRepository.invalidateAll()
         }
     }
 

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/ContentLinkWidget.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/ContentLinkWidget.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
@@ -17,6 +19,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
@@ -124,6 +127,23 @@ fun ContentLinkWidget(
                     )
                 }
             }
+        }
+    }
+}
+
+@Composable
+fun ContentLinkColumn(
+    contentLinks: List<ContentLink>
+) {
+    Column(
+        Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(2.dp)
+    ) {
+        for (l in contentLinks) {
+            ContentLinkWidget(
+                l,
+                Modifier.fillMaxWidth()
+            )
         }
     }
 }


### PR DESCRIPTION
Invalidates the entire cache allowing data reloading.

This is a not-amazing fix for any sync issues that may arise, in particular as a result of the fact that the protobuf deserializer we use does not validate data passed to it, occasionally resulting in junk data being stored to the cache.
