### PR TITLE
Use version number for 0.17.0 version migration

### DIFF
--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/migration/ClearCacheOn017AppMigration.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/migration/ClearCacheOn017AppMigration.kt
@@ -9,7 +9,7 @@ class ClearCacheOn017AppMigration(
 ): AppMigration {
 
     override suspend fun apply(previous: Int, current: Int, name: String) {
-        if (name != "0.17.0") return
+        if (previous <= 704) return // Version number for 0.16.1
         shaRepository.invalidateAll()
     }
 }


### PR DESCRIPTION
Rather than checking if the version == 0.17.0, check if the last version prior to upgrade was <= the version code for 0.16.1
