### PR TITLE
Search for content banners matching stops/route

### DIFF
--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/AlertRepository.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/AlertRepository.kt
@@ -63,7 +63,7 @@ class AlertRepository(
             is AlertDisplayContext.Stop -> {
                 flow {
                     emit(listOfNotNull(contentRepository.banner(
-                        ContentRepository.ROUTE_BANNER_ID.replace("%s", context.stopId)
+                        ContentRepository.STOP_BANNER_ID.replace("%s", context.stopId)
                     )))
                 }
             }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/AlertRepository.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/AlertRepository.kt
@@ -53,6 +53,20 @@ class AlertRepository(
                     )))
                 }
             }
+            is AlertDisplayContext.Route -> {
+                flow {
+                    emit(listOfNotNull(contentRepository.banner(
+                        ContentRepository.ROUTE_BANNER_ID.replace("%s", context.routeId)
+                    )))
+                }
+            }
+            is AlertDisplayContext.Stop -> {
+                flow {
+                    emit(listOfNotNull(contentRepository.banner(
+                        ContentRepository.ROUTE_BANNER_ID.replace("%s", context.stopId)
+                    )))
+                }
+            }
             else -> flowOf(emptyList())
         }
     }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/ContentRepository.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/ContentRepository.kt
@@ -24,6 +24,8 @@ class ContentRepository(
         const val SERVICE_ALERT_ID = "service-alerts"
         const val INFORMATION_FOR_DEVELOPERS_ID = "information-for-developers"
         const val HOME_BANNER_ID = "home"
+        const val ROUTE_BANNER_ID = "route-%s"
+        const val STOP_BANNER_ID = "stop-%s"
 
         const val NATIVE_PREFERENCES_ID = "preferences"
         const val NATIVE_PREFERENCES_ROUTING_ID = "preferences-routing"


### PR DESCRIPTION
## Summary by Sourcery

Add support for displaying content banners targeted to specific routes and stops when resolving alerts.

New Features:
- Surface content banners associated with a given route when alerts are shown in a route context.
- Surface content banners associated with a given stop when alerts are shown in a stop context.

Enhancements:
- Introduce route- and stop-specific content banner identifiers in the content repository for contextual messaging.