### PR TITLE
Release 0.18.0 (rc1)

### DIFF
--- a/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/LastDepartureForStopUseCaseTest.kt
+++ b/shared/src/androidUnitTest/kotlin/cl/emilym/sinatra/domain/LastDepartureForStopUseCaseTest.kt
@@ -696,6 +696,52 @@ class LastDepartureForStopUseCaseTest {
     }
 
     @Test
+    fun `invoke prioritizes next day departure before 3am from over current day future departure`() = runTest {
+        // Given
+        val todayService = mockk<Service>()
+        val tomorrowService = mockk<Service>()
+
+        val todayFutureDeparture = DefaultStopTimetableTime.copy(
+            serviceId = "today-service",
+            routeId = "route1",
+            heading = "City",
+            departureTime = Time.create(23.hours) // Future departure today
+        )
+
+        val tomorrowEarlyDeparture = DefaultStopTimetableTime.copy(
+            serviceId = "tomorrow-service",
+            routeId = "route1",
+            heading = "City",
+            departureTime = Time.create(1.hours) // Future departure tomorrow (before 3am)
+        )
+
+        val servicesAndTimes = createServicesAndTimes(
+            services = listOf(todayService, tomorrowService),
+            times = listOf(todayFutureDeparture, tomorrowEarlyDeparture)
+        )
+
+        every { todayService.id } returns "today-service"
+        every { todayService.active(yesterday, testTimeZone) } returns false
+        every { todayService.active(today, testTimeZone) } returns true
+        every { todayService.active(tomorrow, testTimeZone) } returns false
+
+        every { tomorrowService.id } returns "tomorrow-service"
+        every { tomorrowService.active(yesterday, testTimeZone) } returns false
+        every { tomorrowService.active(today, testTimeZone) } returns false
+        every { tomorrowService.active(tomorrow, testTimeZone) } returns true
+
+        coEvery { servicesAndTimesForStopUseCase(testStopId) } returns servicesAndTimes
+
+        // When
+        val result = useCase(testStopId).first()
+
+        // Then
+        assertEquals(1, result.size)
+        assertEquals("tomorrow-service", result.first().serviceId)
+        assertEquals(1.hours, result.first().departureTime.durationThroughDay)
+    }
+
+    @Test
     fun `invoke filters out school services when ShowSchoolServices is false`() = runTest {
         // Given
         val activeService = mockk<Service>()

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/AlertRepository.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/AlertRepository.kt
@@ -63,7 +63,7 @@ class AlertRepository(
             is AlertDisplayContext.Stop -> {
                 flow {
                     emit(listOfNotNull(contentRepository.banner(
-                        ContentRepository.ROUTE_BANNER_ID.replace("%s", context.stopId)
+                        ContentRepository.STOP_BANNER_ID.replace("%s", context.stopId)
                     )))
                 }
             }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/AlertRepository.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/AlertRepository.kt
@@ -53,6 +53,20 @@ class AlertRepository(
                     )))
                 }
             }
+            is AlertDisplayContext.Route -> {
+                flow {
+                    emit(listOfNotNull(contentRepository.banner(
+                        ContentRepository.ROUTE_BANNER_ID.replace("%s", context.routeId)
+                    )))
+                }
+            }
+            is AlertDisplayContext.Stop -> {
+                flow {
+                    emit(listOfNotNull(contentRepository.banner(
+                        ContentRepository.ROUTE_BANNER_ID.replace("%s", context.stopId)
+                    )))
+                }
+            }
             else -> flowOf(emptyList())
         }
     }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/ContentRepository.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/ContentRepository.kt
@@ -24,6 +24,8 @@ class ContentRepository(
         const val SERVICE_ALERT_ID = "service-alerts"
         const val INFORMATION_FOR_DEVELOPERS_ID = "information-for-developers"
         const val HOME_BANNER_ID = "home"
+        const val ROUTE_BANNER_ID = "route-%s"
+        const val STOP_BANNER_ID = "stop-%s"
 
         const val NATIVE_PREFERENCES_ID = "preferences"
         const val NATIVE_PREFERENCES_ROUTING_ID = "preferences-routing"

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/LastDepartureForStopUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/LastDepartureForStopUseCase.kt
@@ -7,6 +7,7 @@ import cl.emilym.sinatra.data.models.RouteId
 import cl.emilym.sinatra.data.models.StopId
 import cl.emilym.sinatra.data.models.StopTimetableTime
 import cl.emilym.sinatra.data.models.startOfDay
+import cl.emilym.sinatra.data.models.toTodayTime
 import cl.emilym.sinatra.data.repository.Preference
 import cl.emilym.sinatra.data.repository.PreferencesRepository
 import cl.emilym.sinatra.data.repository.RemoteConfigRepository
@@ -33,41 +34,47 @@ class LastDepartureForStopUseCase(
     private val preferencesRepository: PreferencesRepository
 ) {
 
+    companion object {
+        private val CUTOFF_TIME = 3.hours // 3am
+    }
+
     operator fun invoke(
         stopId: StopId,
         routeId: RouteId? = null
     ): Flow<List<IStopTimetableTime>> = flow {
         val scheduleTimeZone = metadataRepository.timeZone()
         val now = clock.now()
-        val days = listOf(now - 1.days, now + 1.days, now)
+        val days = listOf(now - 1.days, now, now + 1.days)
 
         val timesAndServices = servicesAndTimesForStopUseCase(stopId)
-        val activeServices = days.map { now ->
+        val activeServicesByDay = days.map { day ->
             timesAndServices.item.services.filter { it.active(
-                now,
+                day,
                 scheduleTimeZone
             ) }
         }
 
-        if (activeServices.all { it.isEmpty() }) return@flow emit(emptyList())
+        if (activeServicesByDay.all { it.isEmpty() }) return@flow emit(emptyList())
 
         val lasts = mutableMapOf<RouteAndHeading, Array<StopTimetableTime?>>()
 
-        activeServices.forEachIndexed { i, activeServices ->
-            val startOfDay = days[i].startOfDay(scheduleTimeZone)
+        activeServicesByDay.forEachIndexed { dayIndex, activeServices ->
+            val startOfDay = days[dayIndex].startOfDay(scheduleTimeZone)
             activeServices.forEach { activeService ->
                 val relevant = timesAndServices.item.times
                     .filter { it.serviceId == activeService.id }
                     .filterNot { it.last }
                     .run {
+                        // Filter for specific routes when provided
                         when (routeId) {
                             null -> this
                             else -> filter { it.routeId == routeId }
                         }
                     }
                     .run {
-                        when (i) {
-                            1 -> filter { it.departureTime.durationThroughDay < 3.hours }
+                        // Only look for departures before 3am on next day
+                        when (dayIndex) {
+                            2 -> filter { it.departureTime.durationThroughDay < CUTOFF_TIME }
                             else -> this
                         }
                     }
@@ -77,8 +84,8 @@ class LastDepartureForStopUseCase(
                     val referenced = stopTime.withTimeReference(startOfDay)
                     val current = lasts.getOrPut(key){ Array(3) { null } }
 
-                    if (current[i] == null || current[i]!!.departureTime < referenced.departureTime)
-                        current[i] = referenced
+                    if (current[dayIndex] == null || current[dayIndex]!!.departureTime < referenced.departureTime)
+                        current[dayIndex] = referenced
                 }
             }
         }
@@ -87,7 +94,14 @@ class LastDepartureForStopUseCase(
             lasts
                 .values
                 .mapNotNull {
-                    it.filterNotNull().firstOrNull { it.departureTime >= now } ?: it[2]
+                    val yesterday = it[0]
+                    val today = it[1]
+                    val tomorrow = it[2]
+                    when {
+                        yesterday != null && yesterday.departureTime >= now -> yesterday
+                        tomorrow != null -> tomorrow
+                        else -> today
+                    }
                 }
                 .map {
                     when {


### PR DESCRIPTION
* Rewrite logic for determining last departure time of day
* Show content banners on stops and routes if available

## Summary by Sourcery

Refine last departure selection logic and surface content banners on route and stop views.

Bug Fixes:
- Adjust last departure calculation to correctly prioritize early next-day departures before 3am over later same-day departures.

Enhancements:
- Revise last departure lookup across yesterday, today, and tomorrow to choose the most relevant departure per route and heading.
- Add support in the alert repository to load and display content banners scoped to specific routes and stops.
- Introduce route- and stop-specific banner ID formats in the content repository for targeted messaging.