### PR TITLE
Implement countdown to arrival as an option

### DIFF
--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/PreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/PreferencesRepository.kt
@@ -16,6 +16,7 @@ sealed interface Preference<T> {
     data object ShowAccessibilityIconsNavigation: Preference<Boolean>
     data object MetricUnits: Preference<Boolean>
     data object Use24HourUnits: Preference<Time24HSetting>
+    data object CountdownUntilArrival: Preference<Boolean>
 }
 
 @Factory
@@ -32,6 +33,7 @@ class PreferencesRepository(
         internal val ROUTER_SHOW_ACCESSIBILITY_ICONS = booleanPreferencesKey("ROUTER_SHOW_ACCESSIBILITY_ICONS")
         internal val DISPLAY_METRIC_UNITS_KEY = booleanPreferencesKey("DISPLAY_METRIC_UNITS")
         internal val TIME_24H_KEY = stringPreferencesKey("TIME_24H")
+        internal val COUNTDOWN_UNTIL_ARRIVAL = booleanPreferencesKey("COUNTDOWN_UNTIL_ARRIVAL")
     }
 
     private val requiresWheelchair: PreferencesUnit<Boolean> = SimplePreferencesUnit(
@@ -82,6 +84,12 @@ class PreferencesRepository(
         { it.name }
     )
 
+    private val countdownUntilArrival: PreferencesUnit<Boolean> = SimplePreferencesUnit(
+        COUNTDOWN_UNTIL_ARRIVAL,
+        false,
+        preferencesPersistence
+    )
+
     fun <T> preference(preference: Preference<T>): PreferencesUnit<T> = when (preference) {
         is Preference.MaximumWalkingTime -> maximumWalkingTime
         is Preference.MetricUnits -> metric
@@ -90,6 +98,7 @@ class PreferencesRepository(
         is Preference.RequiresWheelchair -> requiresWheelchair
         is Preference.ShowAccessibilityIconsNavigation -> showAccessibilityIconsNavigation
         is Preference.Use24HourUnits -> use24Hour
+        is Preference.CountdownUntilArrival -> countdownUntilArrival
     } as PreferencesUnit<T>
 
 }

--- a/ui/src/commonMain/composeResources/values-zh/strings.xml
+++ b/ui/src/commonMain/composeResources/values-zh/strings.xml
@@ -217,6 +217,10 @@
   <string name="stops_timing_approximate">本服务无固定时刻表，车辆到达时间可能会有所变化。</string>
       
   <string name="accessibility_title">无障碍设施</string>
+
+  <string name="scheduled_delay_late">%1$s（晚点%2$s）</string>
+
+  <string name="scheduled_delay_early">%1$s（早%2$s）</string>
       
   <string name="scheduled_arrival">计划到达%1$s</string>
 
@@ -230,14 +234,6 @@
 
   <string name="approximate_arrival_day">约%1$s到达</string>
 
-  <string name="estimated_arrival_late">预计到达时间为%1$s（晚点%2$s）</string>
-
-  <string name="estimated_arrival_late_day">预计到达时间为%1$s（晚点%2$s）</string>
-
-  <string name="estimated_arrival_early">预计到达时间为%1$s（早%2$s）</string>
-
-  <string name="estimated_arrival_early_day">预计到达时间为%1$s（早%2$s）</string>
-
   <string name="past_departure">于 %1$s 出发</string>
 
   <string name="past_departure_day">于 %1$s 出发</string>
@@ -245,14 +241,6 @@
   <string name="past_departure_approximate">大约在 %1$s 出发</string>
 
   <string name="past_departure_approximate_day">大约在 %1$s 出发</string>
-
-  <string name="past_departure_late">于%1$s出发（晚点 %2$s）</string>
-
-  <string name="past_departure_late_day">于%1$s出发（晚点 %2$s）</string>
-
-  <string name="past_departure_early">于%1$s出发（早于%2$s）</string>
-
-  <string name="past_departure_early_day">于%1$s出发（早于%2$s）</string>
 
   <string name="future_scheduled_departure">预计于%1$s出发</string>
 
@@ -266,14 +254,6 @@
 
   <string name="future_approximate_departure_day">预计于%1$s出发</string>
 
-  <string name="future_estimated_departure_late">预计于%1$s出发（晚点%2$s）</string>
-
-  <string name="future_estimated_departure_late_day">预计于%1$s出发（晚点%2$s）</string>
-
-  <string name="future_estimated_departure_early">预计于%1$s出发（提前%2$s）</string>
-
-  <string name="future_estimated_departure_early_day">预计于%1$s出发（提前%2$s）</string>
-
   <string name="generic_arrival">将于%1$s抵达</string>
 
   <string name="generic_arrival_countdown">将于%1$s后到达</string>
@@ -281,14 +261,6 @@
   <string name="generic_arrival_countdown_now">即将到达</string>
 
   <string name="generic_arrival_day">将于%1$s抵达</string>
-
-  <string name="generic_arrival_late">将于%1$s抵达（延迟%2$s）</string>
-
-  <string name="generic_arrival_late_day">将于%1$s抵达（延迟%2$s）</string>
-
-  <string name="generic_arrival_early">将于%1$s抵达（提前%2$s）</string>
-
-  <string name="generic_arrival_early_day">将于%1$s抵达（提前%2$s）</string>
 
   <string name="generic_departure">将于%1$s出发</string>
 
@@ -298,14 +270,6 @@
 
   <string name="generic_departure_day">将于%1$s出发</string>
 
-  <string name="generic_departure_late">将于%1$s出发（延迟%2$s）</string>
-
-  <string name="generic_departure_late_day">将于%1$s出发（延迟%2$s）</string>
-
-  <string name="generic_departure_early">将于%1$s出发（提前%2$s）</string>
-
-  <string name="generic_departure_early_day">将于%1$s出发（提前%2$s）</string>
-
   <string name="generic_departure_past">已于%1$s出发</string>
 
   <string name="generic_departure_past_countdown">已于%1$s前出发</string>
@@ -313,14 +277,6 @@
   <string name="generic_departure_past_countdown_now">已出发</string>
 
   <string name="generic_departure_past_day">已于%1$s出发</string>
-
-  <string name="generic_departure_past_late">已于%1$s出发（延迟%2$s）</string>
-
-  <string name="generic_departure_past_late_day">已于%1$s出发（延迟%2$s）</string>
-
-  <string name="generic_departure_past_early">已于%1$s出发（提前%2$s）</string>
-
-  <string name="generic_departure_past_early_day">已于%1$s出发（提前%2$s）</string>
 
   <string name="route_with_heading">%1$s 至 %2$s</string>
       

--- a/ui/src/commonMain/composeResources/values-zh/strings.xml
+++ b/ui/src/commonMain/composeResources/values-zh/strings.xml
@@ -276,6 +276,10 @@
 
   <string name="generic_arrival">将于%1$s抵达</string>
 
+  <string name="generic_arrival_countdown">将于%1$s后到达</string>
+
+  <string name="generic_arrival_countdown_now">即将到达</string>
+
   <string name="generic_arrival_day">将于%1$s抵达</string>
 
   <string name="generic_arrival_late">将于%1$s抵达（延迟%2$s）</string>
@@ -288,6 +292,10 @@
 
   <string name="generic_departure">将于%1$s出发</string>
 
+  <string name="generic_departure_countdown">将于%1$s后出发</string>
+
+  <string name="generic_departure_countdown_now">即将出发</string>
+
   <string name="generic_departure_day">将于%1$s出发</string>
 
   <string name="generic_departure_late">将于%1$s出发（延迟%2$s）</string>
@@ -299,6 +307,10 @@
   <string name="generic_departure_early_day">将于%1$s出发（提前%2$s）</string>
 
   <string name="generic_departure_past">已于%1$s出发</string>
+
+  <string name="generic_departure_past_countdown">已于%1$s前出发</string>
+
+  <string name="generic_departure_past_countdown_now">已出发</string>
 
   <string name="generic_departure_past_day">已于%1$s出发</string>
 

--- a/ui/src/commonMain/composeResources/values/strings.xml
+++ b/ui/src/commonMain/composeResources/values/strings.xml
@@ -210,6 +210,7 @@
     <string name="generic_departure_early_day">Departing on %1$s (%2$s early)</string>
     <string name="generic_departure_past">Departed at %1$s</string>
     <string name="generic_departure_past_countdown">Departed %1$s ago</string>
+    <string name="generic_departure_past_countdown_now">Departed now</string>
     <string name="generic_departure_past_day">Departed on %1$s</string>
     <string name="generic_departure_past_late">Departed at %1$s (%2$s late)</string>
     <string name="generic_departure_past_late_day">Departed on %1$s (%2$s late)</string>

--- a/ui/src/commonMain/composeResources/values/strings.xml
+++ b/ui/src/commonMain/composeResources/values/strings.xml
@@ -163,6 +163,8 @@
     <string name="stops_timing_approximate">This service does not follow a fixed timetable and arrival times may vary.</string>
     <string name="accessibility_title">Accessibility</string>
 
+    <string name="scheduled_delay_late">%1$s (%2$s late)</string>
+    <string name="scheduled_delay_early">%1$s (%2$s early)</string>
 
     <string name="scheduled_arrival">Scheduled to arrive at %1$s</string>
     <string name="scheduled_arrival_day">Scheduled to arrive on %1$s</string>
@@ -170,54 +172,32 @@
     <string name="estimated_arrival_day">Expected to arrive on %1$s</string>
     <string name="approximate_arrival">Arriving at approximately %1$s</string>
     <string name="approximate_arrival_day">Arriving at approximately %1$s</string>
-    <string name="estimated_arrival_late">Expected to arrive at %1$s (%2$s late)</string>
-    <string name="estimated_arrival_late_day">Expected to arrive on %1$s (%2$s late)</string>
-    <string name="estimated_arrival_early">Expected to arrive at %1$s (%2$s early)</string>
-    <string name="estimated_arrival_early_day">Expected to arrive on %1$s (%2$s early)</string>
 
     <string name="past_departure">Departed at %1$s</string>
     <string name="past_departure_day">Departed on %1$s</string>
     <string name="past_departure_approximate">Departed at approximately %1$s</string>
     <string name="past_departure_approximate_day">Departed on approximately %1$s</string>
-    <string name="past_departure_late">Departed at %1$s (%2$s late)</string>
-    <string name="past_departure_late_day">Departed on %1$s (%2$s late)</string>
-    <string name="past_departure_early">Departed at %1$s (%2$s early)</string>
-    <string name="past_departure_early_day">Departed on %1$s (%2$s early)</string>
     <string name="future_scheduled_departure">Scheduled to depart at %1$s</string>
     <string name="future_scheduled_departure_day">Scheduled to depart on %1$s</string>
     <string name="future_estimated_departure">Expected to depart at %1$s</string>
     <string name="future_estimated_departure_day">Expected to depart on %1$s</string>
     <string name="future_approximate_departure">Expected to depart at approximately %1$s</string>
     <string name="future_approximate_departure_day">Expected to depart on approximately %1$s</string>
-    <string name="future_estimated_departure_late">Expected to depart at %1$s (%2$s late)</string>
-    <string name="future_estimated_departure_late_day">Expected to depart on %1$s (%2$s late)</string>
-    <string name="future_estimated_departure_early">Expected to depart at %1$s (%2$s early)</string>
-    <string name="future_estimated_departure_early_day">Expected to depart on %1$s (%2$s early)</string>
 
     <string name="generic_arrival">Arriving at %1$s</string>
     <string name="generic_arrival_countdown">Arriving in %1$s</string>
     <string name="generic_arrival_countdown_now">Arriving now</string>
     <string name="generic_arrival_day">Arriving on %1$s</string>
-    <string name="generic_arrival_late">Arriving at %1$s (%2$s late)</string>
-    <string name="generic_arrival_late_day">Arriving on %1$s (%2$s late)</string>
-    <string name="generic_arrival_early">Arriving at %1$s (%2$s early)</string>
-    <string name="generic_arrival_early_day">Arriving on %1$s (%2$s early)</string>
+    <string name="generic_arrival_countdown_late">Arriving in %1$s</string>
+    <string name="generic_arrival_countdown_late_now">Arriving now</string>
     <string name="generic_departure">Departing at %1$s</string>
     <string name="generic_departure_countdown">Departing in %1$s</string>
     <string name="generic_departure_countdown_now">Departing now</string>
     <string name="generic_departure_day">Departing on %1$s</string>
-    <string name="generic_departure_late">Departing at %1$s (%2$s late)</string>
-    <string name="generic_departure_late_day">Departing on %1$s (%2$s late)</string>
-    <string name="generic_departure_early">Departing at %1$s (%2$s early)</string>
-    <string name="generic_departure_early_day">Departing on %1$s (%2$s early)</string>
     <string name="generic_departure_past">Departed at %1$s</string>
     <string name="generic_departure_past_countdown">Departed %1$s ago</string>
     <string name="generic_departure_past_countdown_now">Departed now</string>
     <string name="generic_departure_past_day">Departed on %1$s</string>
-    <string name="generic_departure_past_late">Departed at %1$s (%2$s late)</string>
-    <string name="generic_departure_past_late_day">Departed on %1$s (%2$s late)</string>
-    <string name="generic_departure_past_early">Departed at %1$s (%2$s early)</string>
-    <string name="generic_departure_past_early_day">Departed on %1$s (%2$s early)</string>
 
     <string name="route_with_heading">%1$s towards %2$s</string>
     <string name="route_heading">Towards %1$s</string>

--- a/ui/src/commonMain/composeResources/values/strings.xml
+++ b/ui/src/commonMain/composeResources/values/strings.xml
@@ -30,6 +30,8 @@
     <string name="preferences_setting_show_accessibility_icons_navigation">Highlight Accessibility</string>
     <string name="preferences_setting_show_accessibility_icons_navigation_subtitle">Show whether a journey is bike or wheelchair accessible.</string>
     <string name="preferences_setting_max_walking">Maximum walking time</string>
+    <string name="preferences_setting_countdown">Relative arrival times</string>
+    <string name="preferences_setting_countdown_subtitle">Show vehicle arrival and departure times relative to current time.</string>
     <string name="preferences_setting_metric">Distance Units</string>
     <string name="preferences_setting_metric_subtitle">Display distances in metric (km, m) or imperial (mi, ft) units.</string>
     <string name="preferences_setting_metric_metric">Metric</string>

--- a/ui/src/commonMain/composeResources/values/strings.xml
+++ b/ui/src/commonMain/composeResources/values/strings.xml
@@ -103,6 +103,7 @@
         <item quantity="one">%1$d sec</item>
         <item quantity="other">%1$d secs</item>
     </plurals>
+    <string name="time_minute_less_than_min_short">&lt;1 min</string>
 
     <string name="current_location">Current Location</string>
 
@@ -192,18 +193,23 @@
     <string name="future_estimated_departure_early_day">Expected to depart on %1$s (%2$s early)</string>
 
     <string name="generic_arrival">Arriving at %1$s</string>
+    <string name="generic_arrival_countdown">Arriving in %1$s</string>
+    <string name="generic_arrival_countdown_now">Arriving now</string>
     <string name="generic_arrival_day">Arriving on %1$s</string>
     <string name="generic_arrival_late">Arriving at %1$s (%2$s late)</string>
     <string name="generic_arrival_late_day">Arriving on %1$s (%2$s late)</string>
     <string name="generic_arrival_early">Arriving at %1$s (%2$s early)</string>
     <string name="generic_arrival_early_day">Arriving on %1$s (%2$s early)</string>
     <string name="generic_departure">Departing at %1$s</string>
+    <string name="generic_departure_countdown">Departing in %1$s</string>
+    <string name="generic_departure_countdown_now">Departing now</string>
     <string name="generic_departure_day">Departing on %1$s</string>
     <string name="generic_departure_late">Departing at %1$s (%2$s late)</string>
     <string name="generic_departure_late_day">Departing on %1$s (%2$s late)</string>
     <string name="generic_departure_early">Departing at %1$s (%2$s early)</string>
     <string name="generic_departure_early_day">Departing on %1$s (%2$s early)</string>
     <string name="generic_departure_past">Departed at %1$s</string>
+    <string name="generic_departure_past_countdown">Departed %1$s ago</string>
     <string name="generic_departure_past_day">Departed on %1$s</string>
     <string name="generic_departure_past_late">Departed at %1$s (%2$s late)</string>
     <string name="generic_departure_past_late_day">Departed on %1$s (%2$s late)</string>

--- a/ui/src/commonMain/composeResources/values/strings.xml
+++ b/ui/src/commonMain/composeResources/values/strings.xml
@@ -188,8 +188,6 @@
     <string name="generic_arrival_countdown">Arriving in %1$s</string>
     <string name="generic_arrival_countdown_now">Arriving now</string>
     <string name="generic_arrival_day">Arriving on %1$s</string>
-    <string name="generic_arrival_countdown_late">Arriving in %1$s</string>
-    <string name="generic_arrival_countdown_late_now">Arriving now</string>
     <string name="generic_departure">Departing at %1$s</string>
     <string name="generic_departure_countdown">Departing in %1$s</string>
     <string name="generic_departure_countdown_now">Departing now</string>

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/localization/TimeFormats.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/localization/TimeFormats.kt
@@ -1,6 +1,7 @@
 package cl.emilym.sinatra.ui.localization
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.text.intl.Locale
 import cl.emilym.sinatra.data.models.Time24HSetting
 import cl.emilym.sinatra.data.repository.Preference
@@ -59,18 +60,21 @@ val timeFormat: DateTimeFormat<LocalTime>
     get() {
         val amMarker = stringResource(Res.string.time_am)
         val pmMarker = stringResource(Res.string.time_pm)
-        return when (is24HourTimeFormat()) {
-            true -> LocalTime.Format {
-                hour()
-                char(':')
-                minute()
-            }
-            false -> when {
-                else -> LocalTime.Format {
-                    amPmHour(Padding.NONE)
+        val is24 = is24HourTimeFormat()
+        return remember(is24, amMarker, pmMarker) {
+            when (is24) {
+                true -> LocalTime.Format {
+                    hour()
                     char(':')
                     minute()
-                    amPmMarker(amMarker, pmMarker)
+                }
+                false -> when {
+                    else -> LocalTime.Format {
+                        amPmHour(Padding.NONE)
+                        char(':')
+                        minute()
+                        amPmMarker(amMarker, pmMarker)
+                    }
                 }
             }
         }
@@ -81,15 +85,18 @@ val dayOfWeekDateTimeFormat: DateTimeFormat<LocalDateTime>
     get() {
         val dayOfWeekNames = dayOfWeekNames
         val timeFormat = timeFormat
-        return when(Locale.current.toLanguageTag()) {
-            LanguageConsts.MAINLAND_CHINESE_BCP -> LocalDateTime.Format {
-                dayOfWeek(dayOfWeekNames)
-                time(timeFormat)
-            }
-            else -> LocalDateTime.Format {
-                dayOfWeek(dayOfWeekNames)
-                chars(", ")
-                time(timeFormat)
+        val locale = Locale.current
+        return remember(locale, timeFormat, dayOfWeekNames) {
+            when(locale.toLanguageTag()) {
+                LanguageConsts.MAINLAND_CHINESE_BCP -> LocalDateTime.Format {
+                    dayOfWeek(dayOfWeekNames)
+                    time(timeFormat)
+                }
+                else -> LocalDateTime.Format {
+                    dayOfWeek(dayOfWeekNames)
+                    chars(", ")
+                    time(timeFormat)
+                }
             }
         }
     }
@@ -98,28 +105,30 @@ val dateFormat: DateTimeFormat<LocalDate>
     @Composable
     get() {
         val locale = Locale.current
-        return when(locale.toLanguageTag()) {
-            LanguageConsts.MAINLAND_CHINESE_BCP -> LocalDate.Format {
-                year()
-                char('年')
-                monthNumber()
-                char('月')
-                dayOfMonth()
-                char('日')
-            }
-            LanguageConsts.US_BCP -> LocalDate.Format {
-                monthNumber()
-                char('/')
-                dayOfMonth()
-                char('/')
-                year()
-            }
-            else -> LocalDate.Format {
-                dayOfMonth()
-                char('/')
-                monthNumber()
-                char('/')
-                year()
+        return remember(locale) {
+            when(locale.toLanguageTag()) {
+                LanguageConsts.MAINLAND_CHINESE_BCP -> LocalDate.Format {
+                    year()
+                    char('年')
+                    monthNumber()
+                    char('月')
+                    dayOfMonth()
+                    char('日')
+                }
+                LanguageConsts.US_BCP -> LocalDate.Format {
+                    monthNumber()
+                    char('/')
+                    dayOfMonth()
+                    char('/')
+                    year()
+                }
+                else -> LocalDate.Format {
+                    dayOfMonth()
+                    char('/')
+                    monthNumber()
+                    char('/')
+                    year()
+                }
             }
         }
     }

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/localization/TimeHelpers.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/localization/TimeHelpers.kt
@@ -151,10 +151,12 @@ fun Time.format(): String {
 fun countdown(time: kotlin.time.Instant, negative: Boolean = false): String {
     val remaining = rememberCountdown(time)
 
-    val display by derivedStateOf {
-        when (negative) {
-            true -> -remaining
-            else -> remaining
+    val display by remember(remaining, negative) {
+        derivedStateOf {
+            when (negative) {
+                true -> -remaining
+                else -> remaining
+            }
         }
     }
 

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/localization/TimeHelpers.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/localization/TimeHelpers.kt
@@ -2,6 +2,7 @@ package cl.emilym.sinatra.ui.localization
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -21,10 +22,12 @@ import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.format
 import kotlinx.datetime.toLocalDateTime
+import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
 import sinatra.ui.generated.resources.Res
 import sinatra.ui.generated.resources.time_local_timezone
-import kotlin.time.Duration
+import sinatra.ui.generated.resources.time_minute_less_than_min_short
+import sinatra.ui.generated.resources.time_minute_short
 import kotlin.time.Duration.Companion.minutes
 
 val LocalScheduleTimeZone = staticCompositionLocalOf<TimeZone> { error("Schedule time zone not provided!") }
@@ -50,6 +53,13 @@ fun Time.toTodayInstant(): Instant {
 @Composable
 fun Time.isInPast(): Boolean {
     return toTodayInstant() < LocalClock.current.now()
+}
+
+@Composable
+fun Time.isNowish(): Boolean {
+    val today = toTodayInstant()
+    val now = LocalClock.current.now()
+    return today > (now - 1.minutes) && today < (now + 1.minutes)
 }
 
 @Composable
@@ -95,16 +105,33 @@ fun Time.format(): String {
 }
 
 @Composable
-fun countdown(time: kotlin.time.Instant): String {
+fun countdown(time: kotlin.time.Instant, negative: Boolean = false): String {
     val clock = LocalClock.current
-    var remaining by remember { mutableStateOf(time - clock.now()) }
+    var remaining by remember { mutableStateOf((time - clock.now())) }
 
     LaunchedEffect(time) {
         while (isActive) {
-            delay(remaining - (remaining.inWholeMinutes - 1).minutes)
+            delay(
+                remaining.inWholeMilliseconds.let {
+                    it - (it.floorDiv(60000L) * 60000L)
+                }.coerceAtLeast(0) + 1000L
+            )
             remaining = time - clock.now()
         }
     }
 
-    return (if (remaining.isNegative()) -remaining else remaining).text(true)
+    val display by derivedStateOf {
+        when (negative) {
+            true -> -remaining
+            else -> remaining
+        }
+    }
+
+    return when {
+        display.isPositive() && display <= 1.minutes ->
+            stringResource(Res.string.time_minute_less_than_min_short)
+        display.isNegative() && display >= (-1).minutes ->
+            pluralStringResource(Res.plurals.time_minute_short, 0, 0)
+        else -> display.text(true)
+    }
 }

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/localization/TimeHelpers.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/localization/TimeHelpers.kt
@@ -28,6 +28,8 @@ import sinatra.ui.generated.resources.Res
 import sinatra.ui.generated.resources.time_local_timezone
 import sinatra.ui.generated.resources.time_minute_less_than_min_short
 import sinatra.ui.generated.resources.time_minute_short
+import kotlin.math.abs
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
 val LocalScheduleTimeZone = staticCompositionLocalOf<TimeZone> { error("Schedule time zone not provided!") }
@@ -46,20 +48,54 @@ fun startOfDay(timeZone: TimeZone): Instant {
 }
 
 @Composable
+fun rememberCountdown(instant: kotlin.time.Instant): Duration {
+    val clock = LocalClock.current
+    var countdown by remember(instant, clock) { mutableStateOf(instant - clock.now()) }
+
+    LaunchedEffect(instant, clock) {
+        while (isActive) {
+            delay(
+                countdown.inWholeMilliseconds.let {
+                    when (abs(it) > 60000) {
+                        true -> it - (it.floorDiv(60000L) * 60000L)
+                        else -> 0L
+                    }
+                }.coerceAtLeast(0) + 1000L
+            )
+            countdown = instant - clock.now()
+        }
+    }
+
+    return countdown
+}
+
+@Composable
 fun Time.toTodayInstant(): Instant {
-    return addReference(scheduleStartOfDay()).instant
+    val scheduleStartOfDay = scheduleStartOfDay()
+    return remember(scheduleStartOfDay, this) {
+        addReference(scheduleStartOfDay).instant
+    }
 }
 
 @Composable
 fun Time.isInPast(): Boolean {
-    return toTodayInstant() < LocalClock.current.now()
+    val instant = toTodayInstant()
+    val clock = LocalClock.current
+    val countdown = rememberCountdown(instant)
+    return remember(countdown, clock, instant) {
+        instant < clock.now()
+    }
 }
 
 @Composable
 fun Time.isNowish(): Boolean {
-    val today = toTodayInstant()
-    val now = LocalClock.current.now()
-    return today > (now - 1.minutes) && today < (now + 1.minutes)
+    val instant = toTodayInstant()
+    val clock = LocalClock.current
+    val countdown = rememberCountdown(instant)
+    return remember(countdown, clock, instant) {
+        val now = clock.now()
+        instant > (now - 1.minutes) && instant < (now + 1.minutes)
+    }
 }
 
 @Composable
@@ -83,19 +119,26 @@ fun Instant.format(): String {
 
 @Composable
 fun Instant.isSameDay(timeZone: TimeZone): Boolean {
-    return toLocalDateTime(timeZone).isSameDay(LocalClock.current.now().toLocalDateTime(timeZone))
+    val clock = LocalClock.current
+    return remember(this, timeZone, clock) {
+        toLocalDateTime(timeZone).isSameDay(clock.now().toLocalDateTime(timeZone))
+    }
 }
 
 @Composable
 private fun Instant.format(timeZone: TimeZone): String {
-    val inTz = toLocalDateTime(timeZone)
+    val inTz = remember(this, timeZone) { toLocalDateTime(timeZone) }
+    val sameDay = isSameDay(timeZone)
     val timeFormat = timeFormat
+    val dayOfWeekFormat = dayOfWeekDateTimeFormat
 
-    return when {
-        isSameDay(timeZone) -> inTz.format(LocalDateTime.Format {
-            time(timeFormat)
-        })
-        else -> inTz.format(dayOfWeekDateTimeFormat)
+    return remember(inTz, this, sameDay, timeZone, timeFormat) {
+        when {
+            sameDay -> inTz.format(LocalDateTime.Format {
+                time(timeFormat)
+            })
+            else -> inTz.format(dayOfWeekFormat)
+        }
     }
 }
 
@@ -106,19 +149,7 @@ fun Time.format(): String {
 
 @Composable
 fun countdown(time: kotlin.time.Instant, negative: Boolean = false): String {
-    val clock = LocalClock.current
-    var remaining by remember { mutableStateOf((time - clock.now())) }
-
-    LaunchedEffect(time) {
-        while (isActive) {
-            delay(
-                remaining.inWholeMilliseconds.let {
-                    it - (it.floorDiv(60000L) * 60000L)
-                }.coerceAtLeast(0) + 1000L
-            )
-            remaining = time - clock.now()
-        }
-    }
+    val remaining = rememberCountdown(time)
 
     val display by derivedStateOf {
         when (negative) {

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/localization/TimeHelpers.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/localization/TimeHelpers.kt
@@ -1,12 +1,20 @@
 package cl.emilym.sinatra.ui.localization
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import cl.emilym.sinatra.FeatureFlag
 import cl.emilym.sinatra.data.models.Time
 import cl.emilym.sinatra.data.models.isSameDay
 import cl.emilym.sinatra.data.models.startOfDay
+import cl.emilym.sinatra.ui.text
 import cl.emilym.sinatra.ui.widgets.value
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
@@ -16,6 +24,8 @@ import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
 import sinatra.ui.generated.resources.Res
 import sinatra.ui.generated.resources.time_local_timezone
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
 
 val LocalScheduleTimeZone = staticCompositionLocalOf<TimeZone> { error("Schedule time zone not provided!") }
 val LocalLocalTimeZone = staticCompositionLocalOf<TimeZone> { TimeZone.currentSystemDefault() }
@@ -82,4 +92,19 @@ private fun Instant.format(timeZone: TimeZone): String {
 @Composable
 fun Time.format(): String {
     return toTodayInstant().format()
+}
+
+@Composable
+fun countdown(time: kotlin.time.Instant): String {
+    val clock = LocalClock.current
+    var remaining by remember { mutableStateOf(time - clock.now()) }
+
+    LaunchedEffect(time) {
+        while (isActive) {
+            delay(remaining - (remaining.inWholeMinutes - 1).minutes)
+            remaining = time - clock.now()
+        }
+    }
+
+    return (if (remaining.isNegative()) -remaining else remaining).text(true)
 }

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/preferences/UnitsPreferencesScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/preferences/UnitsPreferencesScreen.kt
@@ -8,10 +8,14 @@ import cafe.adriel.voyager.core.screen.ScreenKey
 import cl.emilym.sinatra.data.models.Time24HSetting
 import cl.emilym.sinatra.data.repository.Preference
 import cl.emilym.sinatra.ui.widgets.form.DropdownOption
+import cl.emilym.sinatra.ui.widgets.form.HorizontalLockup
+import cl.emilym.sinatra.ui.widgets.form.PreferencesCheckbox
 import cl.emilym.sinatra.ui.widgets.form.PreferencesDropdown
 import cl.emilym.sinatra.ui.widgets.form.VerticalLockup
 import org.jetbrains.compose.resources.stringResource
 import sinatra.ui.generated.resources.Res
+import sinatra.ui.generated.resources.preferences_setting_countdown
+import sinatra.ui.generated.resources.preferences_setting_countdown_subtitle
 import sinatra.ui.generated.resources.preferences_setting_metric
 import sinatra.ui.generated.resources.preferences_setting_metric_imperial
 import sinatra.ui.generated.resources.preferences_setting_metric_metric
@@ -31,6 +35,14 @@ class UnitsPreferencesScreen: PreferencesScreen() {
 
     @Composable
     override fun ColumnScope.Preferences() {
+        HorizontalLockup(
+            stringResource(Res.string.preferences_setting_countdown),
+            stringResource(Res.string.preferences_setting_countdown_subtitle),
+            Modifier.fillMaxWidth()
+        ) {
+            PreferencesCheckbox(Preference.CountdownUntilArrival)
+        }
+
         VerticalLockup(
             stringResource(Res.string.preferences_setting_metric),
             stringResource(Res.string.preferences_setting_metric_subtitle),

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/StopCard.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/StopCard.kt
@@ -25,10 +25,14 @@ import cl.emilym.sinatra.data.models.StopAccessibility
 import cl.emilym.sinatra.data.models.StopWheelchairAccessibility
 import cl.emilym.sinatra.data.models.TimetableStationTime
 import cl.emilym.sinatra.data.models.merge
+import cl.emilym.sinatra.data.repository.Preference
 import cl.emilym.sinatra.ui.localization.LocalScheduleTimeZone
+import cl.emilym.sinatra.ui.localization.countdown
 import cl.emilym.sinatra.ui.localization.format
 import cl.emilym.sinatra.ui.localization.isInPast
+import cl.emilym.sinatra.ui.localization.isNowish
 import cl.emilym.sinatra.ui.localization.isSameDay
+import cl.emilym.sinatra.ui.localization.toTodayInstant
 import cl.emilym.sinatra.ui.text
 import org.jetbrains.compose.resources.stringResource
 import sinatra.ui.generated.resources.Res
@@ -51,10 +55,15 @@ import sinatra.ui.generated.resources.future_estimated_departure_late_day
 import sinatra.ui.generated.resources.future_scheduled_departure
 import sinatra.ui.generated.resources.future_scheduled_departure_day
 import sinatra.ui.generated.resources.generic_arrival
+import sinatra.ui.generated.resources.generic_arrival_countdown
+import sinatra.ui.generated.resources.generic_arrival_countdown_now
 import sinatra.ui.generated.resources.generic_arrival_day
 import sinatra.ui.generated.resources.generic_departure
+import sinatra.ui.generated.resources.generic_departure_countdown
+import sinatra.ui.generated.resources.generic_departure_countdown_now
 import sinatra.ui.generated.resources.generic_departure_day
 import sinatra.ui.generated.resources.generic_departure_past
+import sinatra.ui.generated.resources.generic_departure_past_countdown
 import sinatra.ui.generated.resources.generic_departure_past_day
 import sinatra.ui.generated.resources.past_departure
 import sinatra.ui.generated.resources.past_departure_approximate
@@ -209,24 +218,49 @@ val StopStationTime.text: String
         val time = stationTime.time.format()
         val stationTime = stationTime
         val isInPast = stationTime.time.isInPast()
+        val isNowish = stationTime.time.isNowish()
         val hasDay = !stationTime.time.isSameDay(LocalScheduleTimeZone.current)
+        val showCountdown by rememberPreferenceState(Preference.CountdownUntilArrival)
         return when (FeatureFlag.STOP_DETAIL_CONCEAL_LIVENESS_STRING.value()) {
-            true -> stringResource(when (this) {
-                is StopStationTime.Arrival -> when (hasDay) {
-                    true -> Res.string.generic_arrival_day
-                    else -> Res.string.generic_arrival
+            true -> when (showCountdown) {
+                true -> when (isNowish) {
+                    true -> stringResource(
+                        when (this) {
+                            is StopStationTime.Arrival -> Res.string.generic_arrival_countdown_now
+                            is StopStationTime.Departure -> Res.string.generic_departure_countdown_now
+                        }
+                    )
+                    else -> stringResource(
+                        when (this) {
+                            is StopStationTime.Arrival -> Res.string.generic_arrival_countdown
+                            is StopStationTime.Departure -> when(isInPast) {
+                                true -> Res.string.generic_departure_past_countdown
+                                else -> Res.string.generic_departure_countdown
+                            }
+                        },
+                        countdown(
+                            stationTime.time.toTodayInstant(),
+                            isInPast && this is StopStationTime.Departure
+                        )
+                    )
                 }
-                is StopStationTime.Departure -> when (isInPast) {
-                    true -> when (hasDay) {
-                        true -> Res.string.generic_departure_past_day
-                        else -> Res.string.generic_departure_past
+                else -> stringResource(when (this) {
+                    is StopStationTime.Arrival -> when (hasDay) {
+                        true -> Res.string.generic_arrival_day
+                        else -> Res.string.generic_arrival
                     }
-                    else -> when (hasDay) {
-                        true -> Res.string.generic_departure_day
-                        else -> Res.string.generic_departure
+                    is StopStationTime.Departure -> when (isInPast) {
+                        true -> when (hasDay) {
+                            true -> Res.string.generic_departure_past_day
+                            else -> Res.string.generic_departure_past
+                        }
+                        else -> when (hasDay) {
+                            true -> Res.string.generic_departure_day
+                            else -> Res.string.generic_departure
+                        }
                     }
-                }
-            }, time)
+                }, time)
+            }
             else -> when (stationTime) {
                 is StationTime.Scheduled -> stringResource(when (this) {
                     is StopStationTime.Arrival -> when (stationTime.approximate) {

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/StopCard.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/StopCard.kt
@@ -64,6 +64,7 @@ import sinatra.ui.generated.resources.generic_departure_countdown_now
 import sinatra.ui.generated.resources.generic_departure_day
 import sinatra.ui.generated.resources.generic_departure_past
 import sinatra.ui.generated.resources.generic_departure_past_countdown
+import sinatra.ui.generated.resources.generic_departure_past_countdown_now
 import sinatra.ui.generated.resources.generic_departure_past_day
 import sinatra.ui.generated.resources.past_departure
 import sinatra.ui.generated.resources.past_departure_approximate
@@ -227,7 +228,10 @@ val StopStationTime.text: String
                     true -> stringResource(
                         when (this) {
                             is StopStationTime.Arrival -> Res.string.generic_arrival_countdown_now
-                            is StopStationTime.Departure -> Res.string.generic_departure_countdown_now
+                            is StopStationTime.Departure -> when(isInPast) {
+                                true -> Res.string.generic_departure_past_countdown_now
+                                else -> Res.string.generic_departure_countdown_now
+                            }
                         }
                     )
                     else -> stringResource(

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/StopCard.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/StopCard.kt
@@ -40,18 +40,10 @@ import sinatra.ui.generated.resources.approximate_arrival
 import sinatra.ui.generated.resources.approximate_arrival_day
 import sinatra.ui.generated.resources.estimated_arrival
 import sinatra.ui.generated.resources.estimated_arrival_day
-import sinatra.ui.generated.resources.estimated_arrival_early
-import sinatra.ui.generated.resources.estimated_arrival_early_day
-import sinatra.ui.generated.resources.estimated_arrival_late
-import sinatra.ui.generated.resources.estimated_arrival_late_day
 import sinatra.ui.generated.resources.future_approximate_departure
 import sinatra.ui.generated.resources.future_approximate_departure_day
 import sinatra.ui.generated.resources.future_estimated_departure
 import sinatra.ui.generated.resources.future_estimated_departure_day
-import sinatra.ui.generated.resources.future_estimated_departure_early
-import sinatra.ui.generated.resources.future_estimated_departure_early_day
-import sinatra.ui.generated.resources.future_estimated_departure_late
-import sinatra.ui.generated.resources.future_estimated_departure_late_day
 import sinatra.ui.generated.resources.future_scheduled_departure
 import sinatra.ui.generated.resources.future_scheduled_departure_day
 import sinatra.ui.generated.resources.generic_arrival
@@ -70,12 +62,10 @@ import sinatra.ui.generated.resources.past_departure
 import sinatra.ui.generated.resources.past_departure_approximate
 import sinatra.ui.generated.resources.past_departure_approximate_day
 import sinatra.ui.generated.resources.past_departure_day
-import sinatra.ui.generated.resources.past_departure_early
-import sinatra.ui.generated.resources.past_departure_early_day
-import sinatra.ui.generated.resources.past_departure_late
-import sinatra.ui.generated.resources.past_departure_late_day
 import sinatra.ui.generated.resources.scheduled_arrival
 import sinatra.ui.generated.resources.scheduled_arrival_day
+import sinatra.ui.generated.resources.scheduled_delay_early
+import sinatra.ui.generated.resources.scheduled_delay_late
 import sinatra.ui.generated.resources.semantics_stop_listing
 
 sealed interface StopStationTime {
@@ -220,35 +210,39 @@ val StopStationTime.text: String
         val stationTime = stationTime
         val isInPast = stationTime.time.isInPast()
         val isNowish = stationTime.time.isNowish()
+        val late = stationTime is StationTime.Live && stationTime.delay.inWholeSeconds < -60L
+        val early = stationTime is StationTime.Live && stationTime.delay.inWholeSeconds > 60L
         val hasDay = !stationTime.time.isSameDay(LocalScheduleTimeZone.current)
         val showCountdown by rememberPreferenceState(Preference.CountdownUntilArrival)
-        return when (FeatureFlag.STOP_DETAIL_CONCEAL_LIVENESS_STRING.value()) {
-            true -> when (showCountdown) {
-                true -> when (isNowish) {
-                    true -> stringResource(
-                        when (this) {
-                            is StopStationTime.Arrival -> Res.string.generic_arrival_countdown_now
-                            is StopStationTime.Departure -> when(isInPast) {
-                                true -> Res.string.generic_departure_past_countdown_now
-                                else -> Res.string.generic_departure_countdown_now
-                            }
+
+        val timeString = when (showCountdown) {
+            true -> when (isNowish) {
+                true -> stringResource(
+                    when (this) {
+                        is StopStationTime.Arrival -> Res.string.generic_arrival_countdown_now
+                        is StopStationTime.Departure -> when (isInPast) {
+                            true -> Res.string.generic_departure_past_countdown_now
+                            else -> Res.string.generic_departure_countdown_now
                         }
+                    }
+                )
+
+                else -> stringResource(
+                    when (this) {
+                        is StopStationTime.Arrival -> Res.string.generic_arrival_countdown
+                        is StopStationTime.Departure -> when (isInPast) {
+                            true -> Res.string.generic_departure_past_countdown
+                            else -> Res.string.generic_departure_countdown
+                        }
+                    },
+                    countdown(
+                        stationTime.time.toTodayInstant(),
+                        isInPast && this is StopStationTime.Departure
                     )
-                    else -> stringResource(
-                        when (this) {
-                            is StopStationTime.Arrival -> Res.string.generic_arrival_countdown
-                            is StopStationTime.Departure -> when(isInPast) {
-                                true -> Res.string.generic_departure_past_countdown
-                                else -> Res.string.generic_departure_countdown
-                            }
-                        },
-                        countdown(
-                            stationTime.time.toTodayInstant(),
-                            isInPast && this is StopStationTime.Departure
-                        )
-                    )
-                }
-                else -> stringResource(when (this) {
+                )
+            }
+            else -> when (FeatureFlag.STOP_DETAIL_CONCEAL_LIVENESS_STRING.value()) {
+                true -> stringResource(when (this) {
                     is StopStationTime.Arrival -> when (hasDay) {
                         true -> Res.string.generic_arrival_day
                         else -> Res.string.generic_arrival
@@ -264,84 +258,42 @@ val StopStationTime.text: String
                         }
                     }
                 }, time)
-            }
-            else -> when (stationTime) {
-                is StationTime.Scheduled -> stringResource(when (this) {
-                    is StopStationTime.Arrival -> when (stationTime.approximate) {
-                        true -> when (hasDay) {
-                            true -> Res.string.approximate_arrival_day
-                            else -> Res.string.approximate_arrival
-                        }
-                        else -> when (hasDay) {
-                            true -> Res.string.scheduled_arrival_day
-                            else -> Res.string.scheduled_arrival
-                        }
-                    }
-                    is StopStationTime.Departure -> when (isInPast) {
-                        true -> when(stationTime.approximate) {
+                else -> when (stationTime) {
+                    is StationTime.Scheduled -> stringResource(when (this) {
+                        is StopStationTime.Arrival -> when (stationTime.approximate) {
                             true -> when (hasDay) {
-                                true -> Res.string.past_departure_approximate_day
-                                else -> Res.string.past_departure_approximate
+                                true -> Res.string.approximate_arrival_day
+                                else -> Res.string.approximate_arrival
                             }
                             else -> when (hasDay) {
-                                true -> Res.string.past_departure_day
-                                else -> Res.string.past_departure
+                                true -> Res.string.scheduled_arrival_day
+                                else -> Res.string.scheduled_arrival
                             }
                         }
-                        else -> when(stationTime.approximate) {
-                            true -> when (hasDay) {
-                                true -> Res.string.future_approximate_departure_day
-                                else -> Res.string.future_approximate_departure
+                        is StopStationTime.Departure -> when (isInPast) {
+                            true -> when(stationTime.approximate) {
+                                true -> when (hasDay) {
+                                    true -> Res.string.past_departure_approximate_day
+                                    else -> Res.string.past_departure_approximate
+                                }
+                                else -> when (hasDay) {
+                                    true -> Res.string.past_departure_day
+                                    else -> Res.string.past_departure
+                                }
                             }
-                            else -> when (hasDay) {
-                                true -> Res.string.future_scheduled_departure_day
-                                else -> Res.string.future_scheduled_departure
+                            else -> when(stationTime.approximate) {
+                                true -> when (hasDay) {
+                                    true -> Res.string.future_approximate_departure_day
+                                    else -> Res.string.future_approximate_departure
+                                }
+                                else -> when (hasDay) {
+                                    true -> Res.string.future_scheduled_departure_day
+                                    else -> Res.string.future_scheduled_departure
+                                }
                             }
                         }
-                    }
-                }, time)
-                is StationTime.Live -> when {
-                    stationTime.delay.inWholeSeconds < -60L -> stringResource(
-                        when (this) {
-                            is StopStationTime.Arrival -> when (hasDay) {
-                                true -> Res.string.estimated_arrival_early_day
-                                else -> Res.string.estimated_arrival_early
-                            }
-                            is StopStationTime.Departure -> when (isInPast) {
-                                true -> when (hasDay) {
-                                    true -> Res.string.past_departure_early_day
-                                    else -> Res.string.past_departure_early
-                                }
-                                else -> when (hasDay) {
-                                    true -> Res.string.future_estimated_departure_early_day
-                                    else -> Res.string.future_estimated_departure_early
-                                }
-                            }
-                        },
-                        time,
-                        (-stationTime.delay).text
-                    )
-                    stationTime.delay.inWholeSeconds > 60L -> stringResource(
-                        when (this) {
-                            is StopStationTime.Arrival -> when (hasDay) {
-                                true -> Res.string.estimated_arrival_late_day
-                                else -> Res.string.estimated_arrival_late
-                            }
-                            is StopStationTime.Departure -> when (isInPast) {
-                                true -> when (hasDay) {
-                                    true -> Res.string.past_departure_late_day
-                                    else -> Res.string.past_departure_late
-                                }
-                                else -> when (hasDay) {
-                                    true -> Res.string.future_estimated_departure_late_day
-                                    else -> Res.string.future_estimated_departure_late
-                                }
-                            }
-                        },
-                        time,
-                        stationTime.delay.text
-                    )
-                    else -> stringResource(
+                    }, time)
+                    is StationTime.Live -> stringResource(
                         when (this) {
                             is StopStationTime.Arrival -> when (hasDay) {
                                 true -> Res.string.estimated_arrival_day
@@ -362,6 +314,20 @@ val StopStationTime.text: String
                     )
                 }
             }
+        }
+
+        return when {
+            late -> stringResource(
+                Res.string.scheduled_delay_late,
+                timeString,
+                (-stationTime.delay).text
+            )
+            early -> stringResource(
+                Res.string.scheduled_delay_early,
+                timeString,
+                stationTime.delay.text
+            )
+            else -> timeString
         }
     }
 


### PR DESCRIPTION
## Summary by Sourcery

Add an optional countdown-based display for vehicle arrival and departure times and wire it into user preferences and time formatting utilities.

New Features:
- Introduce a user preference to show arrival and departure times as relative countdowns instead of absolute times.
- Add dynamic countdown rendering for stop arrival and departure text, including special handling for near-now times and past departures.

Enhancements:
- Refine time helper utilities to memoize formatting, support countdown computation, and improve day and locale-aware formatting.
- Standardize delay messaging by using shared scheduled delay strings for early and late services instead of multiple specialized variants.