### PR TITLE
Increase location update frequency

### DIFF
--- a/ui/src/androidMain/kotlin/cl/emilym/sinatra/ui/widgets/CurrentLocation.android.kt
+++ b/ui/src/androidMain/kotlin/cl/emilym/sinatra/ui/widgets/CurrentLocation.android.kt
@@ -36,7 +36,7 @@ internal actual fun platformCurrentLocation(accuracy: LocationAccuracy): Flow<Ma
             when (accuracy) {
                 LocationAccuracy.LOW -> TimeUnit.MINUTES.toMillis(10)
                 LocationAccuracy.MEDIUM -> TimeUnit.MINUTES.toMillis(1)
-                LocationAccuracy.HIGH -> TimeUnit.SECONDS.toMillis(30)
+                LocationAccuracy.HIGH -> TimeUnit.SECONDS.toMillis(5)
             }
         )
             .setMinUpdateDistanceMeters(when (accuracy) {

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/CurrentLocation.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/CurrentLocation.kt
@@ -21,7 +21,7 @@ enum class LocationAccuracy {
 internal expect fun platformCurrentLocation(accuracy: LocationAccuracy): Flow<MapLocation?>
 
 @Composable
-fun currentLocation(accuracy: LocationAccuracy = LocationAccuracy.MEDIUM): MapLocation? {
+fun currentLocation(accuracy: LocationAccuracy = LocationAccuracy.HIGH): MapLocation? {
     var hasPermission by remember { mutableStateOf(false) }
     val permissionRequestQueue = LocalPermissionRequestQueue.current
 

--- a/ui/src/iosMain/kotlin/cl/emilym/sinatra/ui/widgets/CurrentLocation.ios.kt
+++ b/ui/src/iosMain/kotlin/cl/emilym/sinatra/ui/widgets/CurrentLocation.ios.kt
@@ -34,7 +34,7 @@ internal actual fun platformCurrentLocation(accuracy: LocationAccuracy): Flow<Ma
             ) {
                 launch {
                     send(didUpdateToLocation.coordinate.toShared())
-                    delay(10000)
+                    delay(5000)
                 }
             }
         }


### PR DESCRIPTION
## Summary by Sourcery

Increase mobile current-location update responsiveness across platforms.

Enhancements:
- Raise default location accuracy to high when consuming the currentLocation composable.
- Shorten high-accuracy location update interval on Android from 30 seconds to 5 seconds.
- Shorten iOS location update throttling delay from 10 seconds to 5 seconds.