### PR TITLE
Make entire checkbox lockup clickable

### DIFF
--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/preferences/RoutingPreferencesScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/preferences/RoutingPreferencesScreen.kt
@@ -14,23 +14,22 @@ import cl.emilym.sinatra.FeatureFlag
 import cl.emilym.sinatra.data.repository.Preference
 import cl.emilym.sinatra.lib.FloatRange
 import cl.emilym.sinatra.ui.text
-import cl.emilym.sinatra.ui.widgets.form.HorizontalLockup
-import cl.emilym.sinatra.ui.widgets.form.PreferencesCheckbox
+import cl.emilym.sinatra.ui.widgets.form.HorizontalPreferencesCheckboxLockup
 import cl.emilym.sinatra.ui.widgets.form.PreferencesFloatSlider
 import cl.emilym.sinatra.ui.widgets.form.VerticalLockup
 import cl.emilym.sinatra.ui.widgets.value
 import org.jetbrains.compose.resources.stringResource
 import sinatra.ui.generated.resources.Res
+import sinatra.ui.generated.resources.preferences_routing_title
 import sinatra.ui.generated.resources.preferences_setting_bikes
 import sinatra.ui.generated.resources.preferences_setting_bikes_subtitle
 import sinatra.ui.generated.resources.preferences_setting_max_walking
-import sinatra.ui.generated.resources.preferences_setting_wheelchair
-import sinatra.ui.generated.resources.preferences_setting_wheelchair_subtitle
-import sinatra.ui.generated.resources.preferences_routing_title
 import sinatra.ui.generated.resources.preferences_setting_school_service
 import sinatra.ui.generated.resources.preferences_setting_school_service_subtitle
 import sinatra.ui.generated.resources.preferences_setting_show_accessibility_icons_navigation
 import sinatra.ui.generated.resources.preferences_setting_show_accessibility_icons_navigation_subtitle
+import sinatra.ui.generated.resources.preferences_setting_wheelchair
+import sinatra.ui.generated.resources.preferences_setting_wheelchair_subtitle
 import kotlin.time.Duration.Companion.minutes
 
 class RoutingPreferencesScreen: PreferencesScreen() {
@@ -45,41 +44,37 @@ class RoutingPreferencesScreen: PreferencesScreen() {
         val showSchoolServiceSettings = FeatureFlag.GLOBAL_ENABLE_SCHOOL_SERVICES.value()
 
         if (showAccessibilitySettings) {
-            HorizontalLockup(
+            HorizontalPreferencesCheckboxLockup(
+                Preference.RequiresWheelchair,
                 stringResource(Res.string.preferences_setting_wheelchair),
                 stringResource(Res.string.preferences_setting_wheelchair_subtitle),
                 Modifier.fillMaxWidth()
-            ) {
-                PreferencesCheckbox(Preference.RequiresWheelchair)
-            }
+            )
 
-            HorizontalLockup(
+            HorizontalPreferencesCheckboxLockup(
+                Preference.RequiresBikes,
                 stringResource(Res.string.preferences_setting_bikes),
                 stringResource(Res.string.preferences_setting_bikes_subtitle),
                 Modifier.fillMaxWidth()
-            ) {
-                PreferencesCheckbox(Preference.RequiresBikes)
-            }
+            )
         }
 
         if (showSchoolServiceSettings) {
-            HorizontalLockup(
+            HorizontalPreferencesCheckboxLockup(
+                Preference.ShowSchoolServices,
                 stringResource(Res.string.preferences_setting_school_service),
                 stringResource(Res.string.preferences_setting_school_service_subtitle),
                 Modifier.fillMaxWidth()
-            ) {
-                PreferencesCheckbox(Preference.ShowSchoolServices)
-            }
+            )
         }
 
         if (showAccessibilitySettings) {
-            HorizontalLockup(
+            HorizontalPreferencesCheckboxLockup(
+                Preference.ShowAccessibilityIconsNavigation,
                 stringResource(Res.string.preferences_setting_show_accessibility_icons_navigation),
                 stringResource(Res.string.preferences_setting_show_accessibility_icons_navigation_subtitle),
                 Modifier.fillMaxWidth()
-            ) {
-                PreferencesCheckbox(Preference.ShowAccessibilityIconsNavigation)
-            }
+            )
         }
 
 

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/preferences/UnitsPreferencesScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/preferences/UnitsPreferencesScreen.kt
@@ -8,8 +8,7 @@ import cafe.adriel.voyager.core.screen.ScreenKey
 import cl.emilym.sinatra.data.models.Time24HSetting
 import cl.emilym.sinatra.data.repository.Preference
 import cl.emilym.sinatra.ui.widgets.form.DropdownOption
-import cl.emilym.sinatra.ui.widgets.form.HorizontalLockup
-import cl.emilym.sinatra.ui.widgets.form.PreferencesCheckbox
+import cl.emilym.sinatra.ui.widgets.form.HorizontalPreferencesCheckboxLockup
 import cl.emilym.sinatra.ui.widgets.form.PreferencesDropdown
 import cl.emilym.sinatra.ui.widgets.form.VerticalLockup
 import org.jetbrains.compose.resources.stringResource
@@ -35,13 +34,12 @@ class UnitsPreferencesScreen: PreferencesScreen() {
 
     @Composable
     override fun ColumnScope.Preferences() {
-        HorizontalLockup(
+        HorizontalPreferencesCheckboxLockup(
+            Preference.CountdownUntilArrival,
             stringResource(Res.string.preferences_setting_countdown),
             stringResource(Res.string.preferences_setting_countdown_subtitle),
             Modifier.fillMaxWidth()
-        ) {
-            PreferencesCheckbox(Preference.CountdownUntilArrival)
-        }
+        )
 
         VerticalLockup(
             stringResource(Res.string.preferences_setting_metric),

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/form/PreferencesCheckbox.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/form/PreferencesCheckbox.kt
@@ -3,6 +3,7 @@ package cl.emilym.sinatra.ui.widgets.form
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import cl.emilym.sinatra.data.repository.Preference
+import cl.emilym.sinatra.ui.widgets.noRippleClickable
 import cl.emilym.sinatra.ui.widgets.rememberPreferenceState
 
 @Composable
@@ -16,4 +17,26 @@ fun PreferencesCheckbox(
         { value = it },
         modifier
     )
+}
+
+@Composable
+fun HorizontalPreferencesCheckboxLockup(
+    preference: Preference<Boolean>,
+    title: String,
+    subtitle: String?,
+    modifier: Modifier = Modifier
+) {
+    var value by rememberPreferenceState(preference)
+    HorizontalLockup(
+        title,
+        subtitle,
+        Modifier.noRippleClickable({
+            value = !value
+        }).then(modifier)
+    ) {
+        SinatraCheckbox(
+            value,
+            { value = it },
+        )
+    }
 }

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/form/PreferencesCheckbox.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/form/PreferencesCheckbox.kt
@@ -30,9 +30,9 @@ fun HorizontalPreferencesCheckboxLockup(
     HorizontalLockup(
         title,
         subtitle,
-        Modifier.noRippleClickable({
+        Modifier.then(modifier).noRippleClickable({
             value = !value
-        }).then(modifier)
+        })
     ) {
         SinatraCheckbox(
             value,


### PR DESCRIPTION
## Summary by Sourcery

Make preference checkboxes toggle when clicking anywhere on their row in routing and units settings screens.

Bug Fixes:
- Enable toggling boolean preferences from the entire lockup row rather than only the checkbox control.

Enhancements:
- Introduce a reusable HorizontalPreferencesCheckboxLockup composable that wires a preference-backed checkbox to a full-width clickable lockup container.