### PR TITLE
Respect STOP_DETAIL_CONCEAL_LIVENESS_STRING feature flag

### DIFF
--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/StopCard.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/widgets/StopCard.kt
@@ -317,6 +317,7 @@ val StopStationTime.text: String
         }
 
         return when {
+            FeatureFlag.STOP_DETAIL_CONCEAL_LIVENESS_STRING.value() -> timeString
             late -> stringResource(
                 Res.string.scheduled_delay_late,
                 timeString,


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Allow stop time text to bypass liveness status strings when the STOP_DETAIL_CONCEAL_LIVENESS_STRING feature flag is active.