### PR TITLE
Release 0.18.1

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -14,11 +14,11 @@ android {
     val appVersionName: String by project
 
     namespace = "cl.emilym.sinatra.android"
-    compileSdk = 35
+    compileSdk = 36
     defaultConfig {
         applicationId = "cl.emilym.sinatra"
         minSdk = 23
-        targetSdk = 35
+        targetSdk = 36
         versionCode = appVersionCode.toInt()
         versionName = appVersionName
     }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -134,7 +134,7 @@ room {
 
 android {
     namespace = "cl.emilym.sinatra"
-    compileSdk = 35
+    compileSdk = 36
     defaultConfig {
         minSdk = 23
     }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/RemoteConfigRepository.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/RemoteConfigRepository.kt
@@ -17,6 +17,7 @@ class RemoteConfigRepository(
         const val DATA_CACHE_PERIOD_MULTIPLIER_KEY = "data_cache_period_multiplier"
         const val NOMINATIM_API_URL_KEY = "nominatim_api_url"
         const val NOMINATIM_EMAIL_KEY = "nominatim_email"
+        const val GOVERNMENT_SOURCES_URL_KEY = "government_sources_url"
         const val NOMINATIM_USER_AGENT_KEY = "nominatim_user_agent"
         const val CONTENT_URL_KEY = "content_url"
         const val MINIMUM_VERSION_KEY = "minimum_version"
@@ -51,6 +52,10 @@ class RemoteConfigRepository(
 
     suspend fun contentUrl(): String? {
         return remoteConfigClient.string(CONTENT_URL_KEY)
+    }
+
+    suspend fun governmentSourcesUrl(): String? {
+        return remoteConfigClient.string(GOVERNMENT_SOURCES_URL_KEY)
     }
 
     suspend fun minimumVersion(): VersionName? {

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -146,7 +146,7 @@ ksp {
 
 android {
     namespace = "cl.emilym.sinatra.ui"
-    compileSdk = 35
+    compileSdk = 36
     defaultConfig {
         minSdk = 23
     }

--- a/ui/src/commonMain/composeResources/values/strings.xml
+++ b/ui/src/commonMain/composeResources/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="navigation_bar_more">More</string>
 
     <string name="browse_option_see_all_service_alerts">See all service updates</string>
+    <string name="browse_option_disclaimer">Sources and disclaimers</string>
     <string name="browse_option_upcoming_routes">Upcoming vehicles to %1$s</string>
 
     <string name="favourites_nothing_favourited">Any routes or stops you favourite can be found here</string>

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/ServiceAlertScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/ServiceAlertScreen.kt
@@ -141,6 +141,11 @@ class ServiceAlertScreen: ContentScreen(ContentRepository.SERVICE_ALERT_ID) {
                             Modifier.fillMaxSize(),
                             contentPadding = innerPadding
                         ) {
+                            (content as? RequestState.Success)?.value?.let { content ->
+                                item {
+                                    RenderBodyContent(content)
+                                }
+                            }
                             items(alerts) {
                                 ServiceAlertCard(
                                     it,

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/BrowseViewModel.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/BrowseViewModel.kt
@@ -10,6 +10,7 @@ import cl.emilym.sinatra.data.models.ServiceAlert
 import cl.emilym.sinatra.data.models.ServiceAlertId
 import cl.emilym.sinatra.data.models.SpecialFavouriteType
 import cl.emilym.sinatra.data.models.distance
+import cl.emilym.sinatra.data.repository.RemoteConfigRepository
 import cl.emilym.sinatra.data.repository.ServiceAlertRepository
 import cl.emilym.sinatra.domain.DisplayRoutesUseCase
 import cl.emilym.sinatra.domain.prompt.FavouriteNearbyStopDeparturesUseCase
@@ -63,7 +64,8 @@ sealed interface BrowsePrompt {
         val stop: StopDepartures
     ): BrowsePrompt
     data class NewServiceUpdate(
-        val serviceAlert: ServiceAlert
+        val serviceAlert: ServiceAlert,
+        val governmentSourcesUrl: String
     ): BrowsePrompt
 }
 
@@ -74,7 +76,8 @@ class BrowseViewModel(
     private val quickNavigateUseCase: QuickNavigateUseCase,
     private val specialAddUseCase: SpecialAddUseCase,
     private val favouriteNearbyStopDeparturesUseCase: FavouriteNearbyStopDeparturesUseCase,
-    private val serviceAlertRepository: ServiceAlertRepository
+    private val serviceAlertRepository: ServiceAlertRepository,
+    private val remoteConfigRepository: RemoteConfigRepository
 ): SinatraScreenModel {
 
     private val _routes = flatRequestStateFlow(defaultConfig) { displayRoutesUseCase().mapLatest { it.item } }
@@ -85,18 +88,22 @@ class BrowseViewModel(
     private val newServices = flatRequestStateFlow(defaultConfig) {
         withContext(Dispatchers.IO) { newServiceUpdateUseCase() }
     }
+
+    private val governmentSourcesUrl = requestStateFlow(defaultConfig) {
+        remoteConfigRepository.governmentSourcesUrl()
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     private val quickNavigation = lastLocation.flatRequestStateFlow(showLoading = false) {
         withContext(Dispatchers.IO) {
-            quickNavigateUseCase(it)
-                .mapLatest {
-                    it.mapNotNull {
-                        QuickNavigationItem.Item(
-                            it.navigation.toNavigationLocation() ?: return@mapNotNull null,
-                            it.specialType
-                        )
-                    }
+            quickNavigateUseCase(it).mapLatest {
+                it.mapNotNull {
+                    QuickNavigationItem.Item(
+                        it.navigation.toNavigationLocation() ?: return@mapNotNull null,
+                        it.specialType
+                    )
                 }
+            }
         }
     }
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -116,18 +123,32 @@ class BrowseViewModel(
         newServices,
         quickNavigation,
         specialAdd,
-        nearbyStopDepartures
-    ) { newServices, quickNavigation, specialAdd, nearbyStopDepartures ->
-        listOfNotNull(
-            ((quickNavigation.unwrap().nullIfEmpty() ?: listOf()) +
-            (specialAdd.unwrap().nullIfEmpty() ?: listOf())).nullIfEmpty()?.let {
-                BrowsePrompt.QuickNavigateGroup(it)
-            },
-            nearbyStopDepartures.unwrap()?.let { BrowsePrompt.LargeNearbyStopDepartures(it) },
-            newServices.unwrap().nullIfEmpty()?.let {
-                BrowsePrompt.NewServiceUpdate(it.first())
+        nearbyStopDepartures,
+        governmentSourcesUrl
+    ) { newServices, quickNavigation, specialAdd, nearbyStopDepartures, governmentSourcesUrl ->
+        buildList {
+            // Add quick navigation
+            buildList {
+                quickNavigation.unwrap()?.let { addAll(it) }
+                specialAdd.unwrap()?.let { addAll(it) }
+            }.nullIfEmpty()?.let {
+                add(BrowsePrompt.QuickNavigateGroup(it))
             }
-        )
+
+            // Add nearby stop information
+            nearbyStopDepartures.unwrap()?.let { add(BrowsePrompt.LargeNearbyStopDepartures(it)) }
+
+            // Add new service alerts
+            val newServices = newServices.unwrap().nullIfEmpty()
+            val governmentSourcesUrl = governmentSourcesUrl.unwrap().nullIfEmpty()
+
+            if (newServices != null && governmentSourcesUrl != null) {
+                add(BrowsePrompt.NewServiceUpdate(
+                    newServices.first(),
+                    governmentSourcesUrl
+                ))
+            }
+        }
     }.state(listOf())
 
     init {
@@ -140,6 +161,7 @@ class BrowseViewModel(
         screenModelScope.launch { specialAdd.retry() }
         screenModelScope.launch { quickNavigation.retry() }
         screenModelScope.launch { nearbyStopDepartures.retry() }
+        screenModelScope.launch { governmentSourcesUrl.retry() }
     }
 
     fun refreshNearby() {

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/NewServiceUpdateBrowseOption.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/NewServiceUpdateBrowseOption.kt
@@ -1,6 +1,7 @@
 package cl.emilym.sinatra.ui.presentation.screens.maps.search.browse
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
@@ -9,14 +10,22 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import cl.emilym.compose.units.rdp
+import cl.emilym.sinatra.ui.presentation.screens.ContentScreen
 import cl.emilym.sinatra.ui.presentation.screens.ServiceAlertScreen
 import cl.emilym.sinatra.ui.widgets.ListCard
 import cl.emilym.sinatra.ui.widgets.ServiceAlertCard
+import cl.emilym.sinatra.ui.widgets.contentRoute
+import cl.emilym.sinatra.ui.widgets.noRippleClickable
 import org.jetbrains.compose.resources.stringResource
 import sinatra.ui.generated.resources.Res
+import sinatra.ui.generated.resources.browse_option_disclaimer
 import sinatra.ui.generated.resources.browse_option_see_all_service_alerts
 
 @Composable
@@ -25,29 +34,49 @@ fun NewServiceUpdateBrowseOption(
     viewModel: BrowseViewModel
 ) {
     val navigator = LocalNavigator.currentOrThrow
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 1.rdp)
-            .clickable { navigator.push(ServiceAlertScreen()) },
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-            contentColor = MaterialTheme.colorScheme.onSurface,
-        )
-    ) {
-        ServiceAlertCard(
-            option.serviceAlert,
+    Column {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 1.rdp)
+                .clickable { navigator.push(ServiceAlertScreen()) },
             colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
                 contentColor = MaterialTheme.colorScheme.onSurface,
-            ),
-            onClick = { viewModel.markAlertViewed(option.serviceAlert.id) }
-        )
-        ListCard(
-            icon = null,
-            onClick = { navigator.push(ServiceAlertScreen()) }
+            )
         ) {
-            Text(stringResource(Res.string.browse_option_see_all_service_alerts))
+            ServiceAlertCard(
+                option.serviceAlert,
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                    contentColor = MaterialTheme.colorScheme.onSurface,
+                ),
+                onClick = { viewModel.markAlertViewed(option.serviceAlert.id) }
+            )
+            ListCard(
+                icon = null,
+                onClick = { navigator.push(ServiceAlertScreen()) }
+            ) {
+                Text(stringResource(Res.string.browse_option_see_all_service_alerts))
+            }
         }
+        val uriHandler = LocalUriHandler.current
+        Text(
+            stringResource(Res.string.browse_option_disclaimer),
+            modifier = Modifier
+                .fillMaxWidth()
+                .noRippleClickable {
+                    uriHandler.openUri("https://sinatra-transport.com/government-sources")
+                }
+                .padding(top = 0.5.rdp)
+                .padding(horizontal = 1.rdp),
+            color = MaterialTheme.colorScheme.onSurface
+                .copy(alpha = 0.8f)
+                .compositeOver(
+                    MaterialTheme.colorScheme.surface
+                ),
+            style = MaterialTheme.typography.labelSmall,
+            textDecoration = TextDecoration.Underline
+        )
     }
 }

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/NewServiceUpdateBrowseOption.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/NewServiceUpdateBrowseOption.kt
@@ -66,7 +66,7 @@ fun NewServiceUpdateBrowseOption(
             modifier = Modifier
                 .fillMaxWidth()
                 .noRippleClickable {
-                    uriHandler.openUri("https://sinatra-transport.com/government-sources")
+                    uriHandler.openUri(option.governmentSourcesUrl)
                 }
                 .padding(top = 0.5.rdp)
                 .padding(horizontal = 1.rdp),


### PR DESCRIPTION
* Bump targetSdk to 36
* Disclaimer about service alert source

## Summary by Sourcery

Add a government-sourced disclaimer link to service updates and prepare the app for Android SDK 36.

New Features:
- Show a disclaimer entry below the new service update card that links to government source information configured via remote config.
- Render service alert body content at the top of the service alerts list when available.

Enhancements:
- Integrate a remote-configed government sources URL into browse prompts for new service updates.

Build:
- Update Android compileSdk and targetSdk versions to 36 across app, shared, and UI modules.

Documentation:
- Add a user-facing string for the new service updates disclaimer entry.