### PR TITLE
Only show routes visible in viewport

### DIFF
--- a/shared/schemas/cl.emilym.sinatra.room.AppDatabase/11.json
+++ b/shared/schemas/cl.emilym.sinatra.room.AppDatabase/11.json
@@ -1,0 +1,948 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 11,
+    "identityHash": "af4649e9fa47ef44c9dc2db4aee4693c",
+    "entities": [
+      {
+        "tableName": "ShaEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sha` TEXT NOT NULL, `type` TEXT NOT NULL, `resource` TEXT NOT NULL, `added` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sha",
+            "columnName": "sha",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resource",
+            "columnName": "resource",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "added",
+            "columnName": "added",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "StopEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `parentStation` TEXT, `name` TEXT NOT NULL, `simpleName` TEXT, `lat` REAL NOT NULL, `lng` REAL NOT NULL, `wheelchairAccessible` TEXT NOT NULL, `visibleZoomedOut` INTEGER DEFAULT NULL, `visibleZoomedIn` INTEGER DEFAULT NULL, `showChildren` INTEGER NOT NULL DEFAULT 0, `searchWeight` REAL DEFAULT NULL, `hasRealtime` INTEGER NOT NULL DEFAULT 0, `schoolServiceOnly` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentStation",
+            "columnName": "parentStation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "simpleName",
+            "columnName": "simpleName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lat",
+            "columnName": "lat",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lng",
+            "columnName": "lng",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wheelchairAccessible",
+            "columnName": "wheelchairAccessible",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "visibleZoomedOut",
+            "columnName": "visibleZoomedOut",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "visibleZoomedIn",
+            "columnName": "visibleZoomedIn",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "showChildren",
+            "columnName": "showChildren",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "searchWeight",
+            "columnName": "searchWeight",
+            "affinity": "REAL",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "hasRealtime",
+            "columnName": "hasRealtime",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "schoolServiceOnly",
+            "columnName": "schoolServiceOnly",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "StopTimetableTimeEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resource` TEXT NOT NULL, `childStopId` TEXT, `routeId` TEXT NOT NULL, `routeCode` TEXT NOT NULL, `serviceId` TEXT NOT NULL, `tripId` TEXT NOT NULL, `arrivalTime` INTEGER NOT NULL, `departureTime` INTEGER NOT NULL, `heading` TEXT NOT NULL, `sequence` INTEGER NOT NULL, `last` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resource",
+            "columnName": "resource",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "childStopId",
+            "columnName": "childStopId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "routeId",
+            "columnName": "routeId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "routeCode",
+            "columnName": "routeCode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceId",
+            "columnName": "serviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tripId",
+            "columnName": "tripId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "arrivalTime",
+            "columnName": "arrivalTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "departureTime",
+            "columnName": "departureTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "heading",
+            "columnName": "heading",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "last",
+            "columnName": "last",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "RouteEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `code` TEXT NOT NULL, `displayCode` TEXT NOT NULL, `color` TEXT, `onColor` TEXT, `name` TEXT NOT NULL, `description` TEXT DEFAULT NULL, `approximateTimings` INTEGER NOT NULL DEFAULT 0, `type` TEXT NOT NULL, `designation` TEXT, `hidden` INTEGER NOT NULL DEFAULT 0, `searchWeight` REAL DEFAULT NULL, `showOnBrowse` INTEGER NOT NULL DEFAULT 0, `eventRoute` INTEGER NOT NULL DEFAULT 0, `moreLink` TEXT DEFAULT NULL, `hasRealtime` INTEGER NOT NULL DEFAULT 0, `schoolServiceOnly` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayCode",
+            "columnName": "displayCode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "onColor",
+            "columnName": "onColor",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "approximateTimings",
+            "columnName": "approximateTimings",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "designation",
+            "columnName": "designation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "hidden",
+            "columnName": "hidden",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "searchWeight",
+            "columnName": "searchWeight",
+            "affinity": "REAL",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "showOnBrowse",
+            "columnName": "showOnBrowse",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "eventRoute",
+            "columnName": "eventRoute",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "moreLink",
+            "columnName": "moreLink",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "hasRealtime",
+            "columnName": "hasRealtime",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "schoolServiceOnly",
+            "columnName": "schoolServiceOnly",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "RouteServiceEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resource` TEXT NOT NULL, `serviceId` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resource",
+            "columnName": "resource",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceId",
+            "columnName": "serviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "RouteTripInformationEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `resource` TEXT NOT NULL, `startTime` INTEGER, `endTime` INTEGER, `bikesAllowed` TEXT NOT NULL, `wheelchairAccessible` TEXT NOT NULL, `heading` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resource",
+            "columnName": "resource",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "startTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "endTime",
+            "columnName": "endTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "bikesAllowed",
+            "columnName": "bikesAllowed",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wheelchairAccessible",
+            "columnName": "wheelchairAccessible",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "heading",
+            "columnName": "heading",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "RouteTripStopEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `routeTripInformationEntityId` INTEGER NOT NULL, `resource` TEXT NOT NULL, `stopId` TEXT NOT NULL, `arrivalTime` INTEGER, `departureTime` INTEGER, `sequence` INTEGER NOT NULL, FOREIGN KEY(`routeTripInformationEntityId`) REFERENCES `RouteTripInformationEntity`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "routeTripInformationEntityId",
+            "columnName": "routeTripInformationEntityId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resource",
+            "columnName": "resource",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stopId",
+            "columnName": "stopId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "arrivalTime",
+            "columnName": "arrivalTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "departureTime",
+            "columnName": "departureTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sequence",
+            "columnName": "sequence",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_RouteTripStopEntity_routeTripInformationEntityId",
+            "unique": false,
+            "columnNames": [
+              "routeTripInformationEntityId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_RouteTripStopEntity_routeTripInformationEntityId` ON `${TABLE_NAME}` (`routeTripInformationEntityId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "RouteTripInformationEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "routeTripInformationEntityId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "TimetableServiceRegularEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `serviceId` TEXT NOT NULL, `monday` INTEGER NOT NULL, `tuesday` INTEGER NOT NULL, `wednesday` INTEGER NOT NULL, `thursday` INTEGER NOT NULL, `friday` INTEGER NOT NULL, `saturday` INTEGER NOT NULL, `sunday` INTEGER NOT NULL, `startDate` INTEGER NOT NULL, `endDate` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceId",
+            "columnName": "serviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "monday",
+            "columnName": "monday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tuesday",
+            "columnName": "tuesday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wednesday",
+            "columnName": "wednesday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thursday",
+            "columnName": "thursday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "friday",
+            "columnName": "friday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "saturday",
+            "columnName": "saturday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sunday",
+            "columnName": "sunday",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "startDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "TimetableServiceExceptionEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `serviceId` TEXT NOT NULL, `date` INTEGER NOT NULL, `type` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceId",
+            "columnName": "serviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "FavouriteEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `routeId` TEXT, `stopId` TEXT, `placeId` TEXT, `heading` TEXT DEFAULT null, `extra` TEXT DEFAULT null, `order` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "routeId",
+            "columnName": "routeId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "stopId",
+            "columnName": "stopId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "placeId",
+            "columnName": "placeId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "heading",
+            "columnName": "heading",
+            "affinity": "TEXT",
+            "defaultValue": "null"
+          },
+          {
+            "fieldPath": "extra",
+            "columnName": "extra",
+            "affinity": "TEXT",
+            "defaultValue": "null"
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "RecentVisitEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `routeId` TEXT, `stopId` TEXT, `placeId` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "routeId",
+            "columnName": "routeId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "stopId",
+            "columnName": "stopId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "placeId",
+            "columnName": "placeId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "PlaceEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `displayName` TEXT NOT NULL, `lat` REAL NOT NULL, `lng` REAL NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lat",
+            "columnName": "lat",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lng",
+            "columnName": "lng",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ServiceAlertEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `url` TEXT, `date` INTEGER, `regions` TEXT NOT NULL, `highlightDuration` TEXT DEFAULT null, `viewed` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "regions",
+            "columnName": "regions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "highlightDuration",
+            "columnName": "highlightDuration",
+            "affinity": "TEXT",
+            "defaultValue": "null"
+          },
+          {
+            "fieldPath": "viewed",
+            "columnName": "viewed",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ContentEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `content` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ContentLinkEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `contentId` TEXT NOT NULL, `type` TEXT NOT NULL, `title` TEXT NOT NULL, `ref` TEXT NOT NULL, `order` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`contentId`) REFERENCES `ContentEntity`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contentId",
+            "columnName": "contentId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ref",
+            "columnName": "ref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ContentLinkEntity_contentId",
+            "unique": false,
+            "columnNames": [
+              "contentId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ContentLinkEntity_contentId` ON `${TABLE_NAME}` (`contentId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "ContentEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "contentId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "RouteLocationIndexEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `lat` REAL NOT NULL, `lng` REAL NOT NULL, `routeIds` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lat",
+            "columnName": "lat",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lng",
+            "columnName": "lng",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "routeIds",
+            "columnName": "routeIds",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'af4649e9fa47ef44c9dc2db4aee4693c')"
+    ]
+  }
+}

--- a/shared/src/commonMain/kotlin/cl/emilym/gtfs/gtfs-api.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/gtfs/gtfs-api.kt
@@ -793,6 +793,38 @@ public data class RealtimeEndpoint(
 }
 
 @pbandk.Export
+public data class RouteLocationIndexEndpoint(
+    val indicies: List<cl.emilym.gtfs.RouteLocationIndex> = emptyList(),
+    override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
+) : pbandk.Message {
+    override operator fun plus(other: pbandk.Message?): cl.emilym.gtfs.RouteLocationIndexEndpoint = protoMergeImpl(other)
+    override val descriptor: pbandk.MessageDescriptor<cl.emilym.gtfs.RouteLocationIndexEndpoint> get() = Companion.descriptor
+    override val protoSize: Int by lazy { super.protoSize }
+    public companion object : pbandk.Message.Companion<cl.emilym.gtfs.RouteLocationIndexEndpoint> {
+        public val defaultInstance: cl.emilym.gtfs.RouteLocationIndexEndpoint by lazy { cl.emilym.gtfs.RouteLocationIndexEndpoint() }
+        override fun decodeWith(u: pbandk.MessageDecoder): cl.emilym.gtfs.RouteLocationIndexEndpoint = cl.emilym.gtfs.RouteLocationIndexEndpoint.decodeWithImpl(u)
+
+        override val descriptor: pbandk.MessageDescriptor<cl.emilym.gtfs.RouteLocationIndexEndpoint> = pbandk.MessageDescriptor(
+            fullName = "proto.RouteLocationIndexEndpoint",
+            messageClass = cl.emilym.gtfs.RouteLocationIndexEndpoint::class,
+            messageCompanion = this,
+            fields = buildList(1) {
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "indicies",
+                        number = 1,
+                        type = pbandk.FieldDescriptor.Type.Repeated<cl.emilym.gtfs.RouteLocationIndex>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = cl.emilym.gtfs.RouteLocationIndex.Companion)),
+                        jsonName = "indicies",
+                        value = cl.emilym.gtfs.RouteLocationIndexEndpoint::indicies
+                    )
+                )
+            }
+        )
+    }
+}
+
+@pbandk.Export
 public data class Stop(
     val id: String,
     val parentStation: String? = null,
@@ -2071,6 +2103,48 @@ public data class RealtimeUpdate(
 }
 
 @pbandk.Export
+public data class RouteLocationIndex(
+    val point: cl.emilym.gtfs.Location,
+    val routeId: List<String> = emptyList(),
+    override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
+) : pbandk.Message {
+    override operator fun plus(other: pbandk.Message?): cl.emilym.gtfs.RouteLocationIndex = protoMergeImpl(other)
+    override val descriptor: pbandk.MessageDescriptor<cl.emilym.gtfs.RouteLocationIndex> get() = Companion.descriptor
+    override val protoSize: Int by lazy { super.protoSize }
+    public companion object : pbandk.Message.Companion<cl.emilym.gtfs.RouteLocationIndex> {
+        override fun decodeWith(u: pbandk.MessageDecoder): cl.emilym.gtfs.RouteLocationIndex = cl.emilym.gtfs.RouteLocationIndex.decodeWithImpl(u)
+
+        override val descriptor: pbandk.MessageDescriptor<cl.emilym.gtfs.RouteLocationIndex> = pbandk.MessageDescriptor(
+            fullName = "proto.RouteLocationIndex",
+            messageClass = cl.emilym.gtfs.RouteLocationIndex::class,
+            messageCompanion = this,
+            fields = buildList(2) {
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "point",
+                        number = 1,
+                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = cl.emilym.gtfs.Location.Companion),
+                        jsonName = "point",
+                        value = cl.emilym.gtfs.RouteLocationIndex::point
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "routeId",
+                        number = 2,
+                        type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
+                        jsonName = "routeId",
+                        value = cl.emilym.gtfs.RouteLocationIndex::routeId
+                    )
+                )
+            }
+        )
+    }
+}
+
+@pbandk.Export
 @pbandk.JsName("orDefaultForStopEndpoint")
 public fun StopEndpoint?.orDefault(): cl.emilym.gtfs.StopEndpoint = this ?: StopEndpoint.defaultInstance
 
@@ -2499,6 +2573,30 @@ private fun RealtimeEndpoint.Companion.decodeWithImpl(u: pbandk.MessageDecoder):
     }
 
     return RealtimeEndpoint(pbandk.ListWithSize.Builder.fixed(updates), expireTimestamp, unknownFields)
+}
+
+@pbandk.Export
+@pbandk.JsName("orDefaultForRouteLocationIndexEndpoint")
+public fun RouteLocationIndexEndpoint?.orDefault(): cl.emilym.gtfs.RouteLocationIndexEndpoint = this ?: RouteLocationIndexEndpoint.defaultInstance
+
+private fun RouteLocationIndexEndpoint.protoMergeImpl(plus: pbandk.Message?): RouteLocationIndexEndpoint = (plus as? RouteLocationIndexEndpoint)?.let {
+    it.copy(
+        indicies = indicies + plus.indicies,
+        unknownFields = unknownFields + plus.unknownFields
+    )
+} ?: this
+
+@Suppress("UNCHECKED_CAST")
+private fun RouteLocationIndexEndpoint.Companion.decodeWithImpl(u: pbandk.MessageDecoder): RouteLocationIndexEndpoint {
+    var indicies: pbandk.ListWithSize.Builder<cl.emilym.gtfs.RouteLocationIndex>? = null
+
+    val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
+        when (_fieldNumber) {
+            1 -> indicies = (indicies ?: pbandk.ListWithSize.Builder()).apply { this += _fieldValue as kotlin.sequences.Sequence<cl.emilym.gtfs.RouteLocationIndex> }
+        }
+    }
+
+    return RouteLocationIndexEndpoint(pbandk.ListWithSize.Builder.fixed(indicies), unknownFields)
 }
 
 private fun Stop.protoMergeImpl(plus: pbandk.Message?): Stop = (plus as? Stop)?.let {
@@ -3154,4 +3252,30 @@ private fun RealtimeUpdate.Companion.decodeWithImpl(u: pbandk.MessageDecoder): R
         throw pbandk.InvalidProtocolBufferException.missingRequiredField("tripId")
     }
     return RealtimeUpdate(tripId!!, delay, unknownFields)
+}
+
+private fun RouteLocationIndex.protoMergeImpl(plus: pbandk.Message?): RouteLocationIndex = (plus as? RouteLocationIndex)?.let {
+    it.copy(
+        point = point.plus(plus.point),
+        routeId = routeId + plus.routeId,
+        unknownFields = unknownFields + plus.unknownFields
+    )
+} ?: this
+
+@Suppress("UNCHECKED_CAST")
+private fun RouteLocationIndex.Companion.decodeWithImpl(u: pbandk.MessageDecoder): RouteLocationIndex {
+    var point: cl.emilym.gtfs.Location? = null
+    var routeId: pbandk.ListWithSize.Builder<String>? = null
+
+    val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
+        when (_fieldNumber) {
+            1 -> point = _fieldValue as cl.emilym.gtfs.Location
+            2 -> routeId = (routeId ?: pbandk.ListWithSize.Builder()).apply { this += _fieldValue as kotlin.sequences.Sequence<String> }
+        }
+    }
+
+    if (point == null) {
+        throw pbandk.InvalidProtocolBufferException.missingRequiredField("point")
+    }
+    return RouteLocationIndex(point!!, pbandk.ListWithSize.Builder.fixed(routeId), unknownFields)
 }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/client/RouteClient.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/client/RouteClient.kt
@@ -2,6 +2,7 @@ package cl.emilym.sinatra.data.client
 
 import cl.emilym.sinatra.data.models.Route
 import cl.emilym.sinatra.data.models.RouteId
+import cl.emilym.sinatra.data.models.RouteLocationIndex
 import cl.emilym.sinatra.data.models.RouteServiceCanonicalTimetable
 import cl.emilym.sinatra.data.models.RouteServiceTimetable
 import cl.emilym.sinatra.data.models.RouteTripTimetable
@@ -22,6 +23,13 @@ class RouteClient(
         object : ValidatedEndpointDigestPair<List<Route>>() {
             override val endpoint = ::routes
             override val digest = ::routesDigest
+        }
+    }
+
+    val routeLocationIndexEndpointPair by lazy {
+        object : ValidatedEndpointDigestPair<List<RouteLocationIndex>>() {
+            override val endpoint = ::routeLocationIndex
+            override val digest = ::routeLocationIndexDigest
         }
     }
 
@@ -59,6 +67,15 @@ class RouteClient(
 
     suspend fun routesDigest(): ShaDigest {
         return gtfsApi.routesDigest()
+    }
+
+    suspend fun routeLocationIndex(digest: ShaDigest): List<RouteLocationIndex> {
+        val pbIndicies = gtfsApi.routeLocationIndex().validated(digest)
+        return pbIndicies.indicies.map { RouteLocationIndex.fromPB(it) }
+    }
+
+    suspend fun routeLocationIndexDigest(): ShaDigest {
+        return gtfsApi.routeLocationIndexDigest()
     }
 
     suspend fun routeServices(digest: ShaDigest, routeId: RouteId): List<ServiceId> {

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Local.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Local.kt
@@ -7,6 +7,7 @@ enum class CacheCategory(
     STOP("stop"),
     STOP_TIMETABLE("stop-timetable"),
     ROUTE("route"),
+    ROUTE_LOCATION_INDEX("route_location_index"),
     SERVICE("service"),
     ROUTE_SERVICE("route_service"),
     ROUTE_SERVICE_TIMETABLE("route_service_timetable"),

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Location.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Location.kt
@@ -78,6 +78,8 @@ data class MapRegion(
     )
     val center: MapLocation get() = naiveCenter
 
+    val diagonalDistance: Kilometer get() = distance(northEast, southWest)
+
     fun contains(location: MapLocation): Boolean {
         return location.lat <= topLeft.lat && location.lat >= bottomRight.lat &&
                 location.lng >= topLeft.lng && location.lng <= bottomRight.lng

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Route.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Route.kt
@@ -178,3 +178,19 @@ data class RouteTripStop(
     }
 
 }
+
+data class RouteLocationIndex(
+    val point: MapLocation,
+    val routeIds: List<RouteId>
+) {
+
+    companion object {
+        fun fromPB(pb: cl.emilym.gtfs.RouteLocationIndex): RouteLocationIndex {
+            return RouteLocationIndex(
+                point = MapLocation.fromPB(pb.point),
+                routeIds = pb.routeId
+            )
+        }
+    }
+
+}

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/persistence/RouteLocationIndexPersistence.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/persistence/RouteLocationIndexPersistence.kt
@@ -11,7 +11,7 @@ class RouteLocationIndexPersistence(
 ) {
 
     suspend fun save(routeLocationIndices: List<RouteLocationIndex>) {
-        routeLocationIndexDao.insert(*routeLocationIndices.map {
+        routeLocationIndexDao.clearAndInsert(*routeLocationIndices.map {
             RouteLocationIndexEntity.fromModel(it)
         }.toTypedArray())
     }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/persistence/RouteLocationIndexPersistence.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/persistence/RouteLocationIndexPersistence.kt
@@ -1,0 +1,40 @@
+package cl.emilym.sinatra.data.persistence
+
+import cl.emilym.sinatra.data.models.RouteLocationIndex
+import cl.emilym.sinatra.room.dao.RouteLocationIndexDao
+import cl.emilym.sinatra.room.entities.RouteLocationIndexEntity
+import org.koin.core.annotation.Factory
+
+@Factory
+class RouteLocationIndexPersistence(
+    private val routeLocationIndexDao: RouteLocationIndexDao
+) {
+
+    suspend fun save(routeLocationIndices: List<RouteLocationIndex>) {
+        routeLocationIndexDao.insert(*routeLocationIndices.map {
+            RouteLocationIndexEntity.fromModel(it)
+        }.toTypedArray())
+    }
+
+    suspend fun clear() {
+        routeLocationIndexDao.clear()
+    }
+
+    suspend fun get(): List<RouteLocationIndex> {
+        return routeLocationIndexDao.get().map {
+            it.toModel()
+        }
+    }
+
+    suspend fun getInBox(
+        southLat: Double,
+        westLng: Double,
+        northLat: Double,
+        eastLng: Double
+    ): List<RouteLocationIndex> {
+        return routeLocationIndexDao.getInBox(
+            southLat, westLng, northLat, eastLng
+        ).map { it.toModel() }
+    }
+
+}

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/RouteRepository.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/repository/RouteRepository.kt
@@ -3,9 +3,11 @@ package cl.emilym.sinatra.data.repository
 import cl.emilym.sinatra.data.client.RouteClient
 import cl.emilym.sinatra.data.models.Cachable
 import cl.emilym.sinatra.data.models.CacheCategory
+import cl.emilym.sinatra.data.models.MapRegion
 import cl.emilym.sinatra.data.models.ResourceKey
 import cl.emilym.sinatra.data.models.Route
 import cl.emilym.sinatra.data.models.RouteId
+import cl.emilym.sinatra.data.models.RouteLocationIndex
 import cl.emilym.sinatra.data.models.RouteServiceCanonicalTimetable
 import cl.emilym.sinatra.data.models.RouteServiceTimetable
 import cl.emilym.sinatra.data.models.RouteTripTimetable
@@ -13,6 +15,7 @@ import cl.emilym.sinatra.data.models.ServiceId
 import cl.emilym.sinatra.data.models.TripId
 import cl.emilym.sinatra.data.models.flatMap
 import cl.emilym.sinatra.data.models.map
+import cl.emilym.sinatra.data.persistence.RouteLocationIndexPersistence
 import cl.emilym.sinatra.data.persistence.RoutePersistence
 import cl.emilym.sinatra.data.persistence.RouteServiceCanonicalTimetablePersistence
 import cl.emilym.sinatra.data.persistence.RouteServicePersistence
@@ -137,6 +140,27 @@ class RouteTripTimetableCacheWorker(
 }
 
 @Factory
+class RouteLocationIndexCacheWorker(
+    private val routePersistence: RouteLocationIndexPersistence,
+    private val routeClient: RouteClient,
+    override val cacheWorkerDependencies: CacheWorkerDependencies,
+    override val clock: Clock,
+): CacheWorker<List<RouteLocationIndex>>() {
+
+    override val cacheCategory: CacheCategory = CacheCategory.ROUTE_LOCATION_INDEX
+
+    override suspend fun saveToPersistence(data: List<RouteLocationIndex>, resource: ResourceKey) =
+        routePersistence.save(data)
+    override suspend fun getFromPersistence(resource: ResourceKey): List<RouteLocationIndex> =
+        routePersistence.get()
+
+    suspend fun get(): Cachable<List<RouteLocationIndex>> {
+        return run(routeClient.routeLocationIndexEndpointPair, "routes")
+    }
+
+}
+
+@Factory
 class RouteCleanupWorker(
     private val routePersistence: RoutePersistence,
     override val shaRepository: ShaRepository,
@@ -200,6 +224,18 @@ class RouteTripTimetableCleanupWorker(
 }
 
 @Factory
+class RouteLocationIndexCleanupWorker(
+    private val routePersistence: RouteLocationIndexPersistence,
+    override val shaRepository: ShaRepository,
+    override val clock: Clock
+): CleanupWorker() {
+
+    override val cacheCategory: CacheCategory = CacheCategory.ROUTE_LOCATION_INDEX
+    override suspend fun delete(resource: ResourceKey) = routePersistence.clear()
+
+}
+
+@Factory
 class RouteRepository(
     private val routeCacheWorker: RoutesCacheWorker,
     private val routeServicesCacheWorker: RouteServicesCacheWorker,
@@ -212,7 +248,10 @@ class RouteRepository(
     private val routeServiceTimetableCleanupWorker: RouteServiceTimetableCleanupWorker,
     private val routeServiceCanonicalTimetableCleanupWorker: RouteServiceCanonicalTimetableCleanupWorker,
     private val routeTripTimetableCleanupWorker: RouteTripTimetableCleanupWorker,
+    private val routeLocationIndexCacheWorker: RouteLocationIndexCacheWorker,
+    private val routeLocationIndexCleanupWorker: RouteLocationIndexCleanupWorker,
     private val routePersistence: RoutePersistence,
+    private val routeLocationIndexPersistence: RouteLocationIndexPersistence,
     private val transportMetadataRepository: TransportMetadataRepository
 ) {
 
@@ -258,6 +297,19 @@ class RouteRepository(
         ) }
     }
 
+    suspend fun routesInBox(region: MapRegion): List<Route> {
+        val routes = routeCacheWorker.get()
+        routeLocationIndexCacheWorker.get()
+        val index = routeLocationIndexPersistence.getInBox(
+            region.southWest.lat,
+            region.southWest.lng,
+            region.northEast.lat,
+            region.northEast.lng
+        ).flatMap { it.routeIds }.associateWith { true }
+
+        return routes.item.filter { index[it.id] == true }
+    }
+
     suspend fun removedRoutes(): List<RouteId> {
         return listOf("NIS")
     }
@@ -268,6 +320,7 @@ class RouteRepository(
         routeServiceTimetableCleanupWorker()
         routeServiceCanonicalTimetableCleanupWorker()
         routeTripTimetableCleanupWorker()
+        routeLocationIndexCleanupWorker()
     }
 
 }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/RegionDistinctUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/RegionDistinctUseCase.kt
@@ -6,7 +6,7 @@ import org.koin.core.annotation.Factory
 import kotlin.math.abs
 
 @Factory
-class RegionDistinctUseCase() {
+class RegionDistinctUseCase {
 
     operator fun invoke(old: MapRegion, new: MapRegion): Boolean {
         val centerDistance = distance(old.center, new.center)
@@ -40,8 +40,8 @@ class RegionDistinctUseCase() {
     companion object {
         const val MOVE_THRESHOLD_RATIO: Double = 0.15
         const val RESIZE_THRESHOLD_RATIO: Double = 0.20
-        const val MIN_DIAGONAL_SIZE_CHECK: Double = 50.0
-        const val MIN_ABSOLUTE_MOVE_DISTANCE: Double = 5.0
+        const val MIN_DIAGONAL_SIZE_CHECK: Double = 0.05
+        const val MIN_ABSOLUTE_MOVE_DISTANCE: Double = 0.05
     }
 
 }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/RegionDistinctUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/RegionDistinctUseCase.kt
@@ -1,0 +1,47 @@
+package cl.emilym.sinatra.domain
+
+import cl.emilym.sinatra.data.models.MapRegion
+import cl.emilym.sinatra.data.models.distance
+import org.koin.core.annotation.Factory
+import kotlin.math.abs
+
+@Factory
+class RegionDistinctUseCase() {
+
+    operator fun invoke(old: MapRegion, new: MapRegion): Boolean {
+        val centerDistance = distance(old.center, new.center)
+
+        // Use the larger of the two diagonals as the reference scale for movement,
+        // so a shrinking region doesn't make movement checks artificially strict.
+        val referenceDiagonal = maxOf(old.diagonalDistance, new.diagonalDistance)
+        val moveThreshold = maxOf(
+            referenceDiagonal * MOVE_THRESHOLD_RATIO,
+            MIN_ABSOLUTE_MOVE_DISTANCE
+        )
+
+        val hasMoved = centerDistance > moveThreshold
+
+        // Only bother checking resize if at least one region is "big enough"
+        // to care about; below that, size differences are noise.
+        val bothSmall = old.diagonalDistance < MIN_DIAGONAL_SIZE_CHECK &&
+                new.diagonalDistance < MIN_DIAGONAL_SIZE_CHECK
+
+        val hasResized = if (bothSmall) {
+            false
+        } else {
+            val relativeSizeChange = abs(new.diagonalDistance - old.diagonalDistance) /
+                    maxOf(old.diagonalDistance, 1e-9) // guard div-by-zero
+            relativeSizeChange > RESIZE_THRESHOLD_RATIO
+        }
+
+        return hasMoved || hasResized
+    }
+
+    companion object {
+        const val MOVE_THRESHOLD_RATIO: Double = 0.15
+        const val RESIZE_THRESHOLD_RATIO: Double = 0.20
+        const val MIN_DIAGONAL_SIZE_CHECK: Double = 50.0
+        const val MIN_ABSOLUTE_MOVE_DISTANCE: Double = 5.0
+    }
+
+}

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/RoutesInAreaUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/RoutesInAreaUseCase.kt
@@ -23,17 +23,7 @@ class RoutesInAreaUseCase(
     private val getFilteredRoutesUseCase: GetFilteredRoutesUseCase
 ) {
 
-    operator fun invoke(area: MapRegion?): Flow<RoutesInArea> = flow {
-        if (area == null || area.diagonalDistance > MAX_DIAGONAL_DISTANCE) {
-            emitAll(getFilteredRoutesUseCase().map {
-                RoutesInArea(
-                    it.item,
-                    false
-                )
-            })
-            return@flow
-        }
-
+    operator fun invoke(area: MapRegion): Flow<RoutesInArea> = flow {
         emitAll(
             getFilteredRoutesUseCase.filterRoutes(routeRepository.routesInBox(area)).map {
                 RoutesInArea(
@@ -49,10 +39,6 @@ class RoutesInAreaUseCase(
                 })
             }
         )
-    }
-
-    companion object {
-        const val MAX_DIAGONAL_DISTANCE = 10.0
     }
 
 }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/RoutesInAreaUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/RoutesInAreaUseCase.kt
@@ -3,8 +3,12 @@ package cl.emilym.sinatra.domain
 import cl.emilym.sinatra.data.models.MapRegion
 import cl.emilym.sinatra.data.models.Route
 import cl.emilym.sinatra.data.repository.RouteRepository
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Factory
 
 data class RoutesInArea(
@@ -14,22 +18,31 @@ data class RoutesInArea(
 
 @Factory
 class RoutesInAreaUseCase(
-    private val routeRepository: RouteRepository
+    private val routeRepository: RouteRepository,
+    private val getFilteredRoutesUseCase: GetFilteredRoutesUseCase
 ) {
 
-    operator fun invoke(area: MapRegion): Flow<RoutesInArea> = flow {
-        if (area.diagonalDistance > MAX_DIAGONAL_DISTANCE) {
-            emit(RoutesInArea(
-                routeRepository.routes().item,
-                false
-            ))
+    operator fun invoke(area: MapRegion?): Flow<RoutesInArea> = flow {
+        if (area == null || area.diagonalDistance > MAX_DIAGONAL_DISTANCE) {
+            emitAll(getFilteredRoutesUseCase().map {
+                RoutesInArea(
+                    it.item,
+                    false
+                )
+            })
             return@flow
         }
 
-        emit(RoutesInArea(
-            routeRepository.routesInBox(area),
-            true
-        ))
+        withContext(Dispatchers.Default) {
+            emitAll(
+                getFilteredRoutesUseCase.filterRoutes(routeRepository.routesInBox(area)).map {
+                    RoutesInArea(
+                        it,
+                        true
+                    )
+                }
+            )
+        }
     }
 
     companion object {

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/RoutesInAreaUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/RoutesInAreaUseCase.kt
@@ -1,0 +1,39 @@
+package cl.emilym.sinatra.domain
+
+import cl.emilym.sinatra.data.models.MapRegion
+import cl.emilym.sinatra.data.models.Route
+import cl.emilym.sinatra.data.repository.RouteRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import org.koin.core.annotation.Factory
+
+data class RoutesInArea(
+    val routes: List<Route>,
+    val isRelevantToRegion: Boolean
+)
+
+@Factory
+class RoutesInAreaUseCase(
+    private val routeRepository: RouteRepository
+) {
+
+    operator fun invoke(area: MapRegion): Flow<RoutesInArea> = flow {
+        if (area.diagonalDistance > MAX_DIAGONAL_DISTANCE) {
+            emit(RoutesInArea(
+                routeRepository.routes().item,
+                false
+            ))
+            return@flow
+        }
+
+        emit(RoutesInArea(
+            routeRepository.routesInBox(area),
+            true
+        ))
+    }
+
+    companion object {
+        const val MAX_DIAGONAL_DISTANCE = 10.0
+    }
+
+}

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/RoutesInAreaUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/RoutesInAreaUseCase.kt
@@ -5,6 +5,7 @@ import cl.emilym.sinatra.data.models.Route
 import cl.emilym.sinatra.data.repository.RouteRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
@@ -33,16 +34,21 @@ class RoutesInAreaUseCase(
             return@flow
         }
 
-        withContext(Dispatchers.Default) {
-            emitAll(
-                getFilteredRoutesUseCase.filterRoutes(routeRepository.routesInBox(area)).map {
+        emitAll(
+            getFilteredRoutesUseCase.filterRoutes(routeRepository.routesInBox(area)).map {
+                RoutesInArea(
+                    it,
+                    true
+                )
+            }.catch {
+                emitAll(getFilteredRoutesUseCase().map {
                     RoutesInArea(
-                        it,
-                        true
+                        it.item,
+                        false
                     )
-                }
-            )
-        }
+                })
+            }
+        )
     }
 
     companion object {

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/network/GtfsApi.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/network/GtfsApi.kt
@@ -4,6 +4,7 @@ import cl.emilym.gtfs.RealtimeEndpoint
 import cl.emilym.gtfs.RouteCanonicalTimetableEndpoint
 import cl.emilym.gtfs.RouteCanonicalTimetableEndpointV2
 import cl.emilym.gtfs.RouteEndpoint
+import cl.emilym.gtfs.RouteLocationIndexEndpoint
 import cl.emilym.gtfs.RouteServicesEndpoint
 import cl.emilym.gtfs.RouteTimetableEndpoint
 import cl.emilym.gtfs.RouteTripTimetableEndpoint
@@ -47,6 +48,12 @@ interface GtfsApi {
 
     @GET("v1/routes.pb.sha")
     suspend fun routesDigest(): String
+
+    @GET("v1/route/location-index.pb")
+    suspend fun routeLocationIndex(): DigestedResponse<RouteLocationIndexEndpoint>
+
+    @GET("v1/route/location-index.pb.sha")
+    suspend fun routeLocationIndexDigest(): String
 
     @GET("v1/route/{routeId}/services.pb")
     suspend fun routeServices(

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/network/HttpMiddleware.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/network/HttpMiddleware.kt
@@ -5,6 +5,7 @@ import cl.emilym.gtfs.RouteCanonicalTimetableEndpoint
 import cl.emilym.gtfs.RouteCanonicalTimetableEndpointV2
 import cl.emilym.gtfs.RouteDetailEndpoint
 import cl.emilym.gtfs.RouteEndpoint
+import cl.emilym.gtfs.RouteLocationIndexEndpoint
 import cl.emilym.gtfs.RouteServicesEndpoint
 import cl.emilym.gtfs.RouteTimetableEndpoint
 import cl.emilym.gtfs.RouteTripTimetableEndpoint
@@ -83,7 +84,8 @@ private val protobufFactories: Map<KClass<*>, ProtobufFactory<*>> = mapOf(
     Pages::class to Pages::decodeFromByteArray,
     FeedMessage::class to FeedMessage::decodeFromByteArray,
     ServiceAlertEndpoint::class to ServiceAlertEndpoint::decodeFromByteArray,
-    RealtimeEndpoint::class to RealtimeEndpoint::decodeFromByteArray
+    RealtimeEndpoint::class to RealtimeEndpoint::decodeFromByteArray,
+    RouteLocationIndexEndpoint::class to RouteLocationIndexEndpoint::decodeFromByteArray,
 )
 
 @Factory

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/room/Database.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/room/Database.kt
@@ -12,6 +12,7 @@ import cl.emilym.sinatra.room.dao.FavouriteDao
 import cl.emilym.sinatra.room.dao.PlaceDao
 import cl.emilym.sinatra.room.dao.RecentVisitDao
 import cl.emilym.sinatra.room.dao.RouteDao
+import cl.emilym.sinatra.room.dao.RouteLocationIndexDao
 import cl.emilym.sinatra.room.dao.RouteServiceEntityDao
 import cl.emilym.sinatra.room.dao.RouteTripInformationEntityDao
 import cl.emilym.sinatra.room.dao.RouteTripStopEntityDao
@@ -27,6 +28,7 @@ import cl.emilym.sinatra.room.entities.FavouriteEntity
 import cl.emilym.sinatra.room.entities.PlaceEntity
 import cl.emilym.sinatra.room.entities.RecentVisitEntity
 import cl.emilym.sinatra.room.entities.RouteEntity
+import cl.emilym.sinatra.room.entities.RouteLocationIndexEntity
 import cl.emilym.sinatra.room.entities.RouteServiceEntity
 import cl.emilym.sinatra.room.entities.RouteTripInformationEntity
 import cl.emilym.sinatra.room.entities.RouteTripStopEntity
@@ -69,7 +71,8 @@ expect object AppDatabaseConstructor : RoomDatabaseConstructor<AppDatabase> {
         PlaceEntity::class,
         ServiceAlertEntity::class,
         ContentEntity::class,
-        ContentLinkEntity::class
+        ContentLinkEntity::class,
+        RouteLocationIndexEntity::class
     ],
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
@@ -89,9 +92,13 @@ expect object AppDatabaseConstructor : RoomDatabaseConstructor<AppDatabase> {
             to = 10,
             spec = Migration9to10::class
         ),
+        AutoMigration(
+            from = 10,
+            to = 11
+        )
     ],
     exportSchema = true,
-    version = 10
+    version = 11
 )
 @ConstructedBy(AppDatabaseConstructor::class)
 abstract class AppDatabase: RoomDatabase() {
@@ -110,6 +117,7 @@ abstract class AppDatabase: RoomDatabase() {
     abstract fun serviceAlertDao(): ServiceAlertDao
     abstract fun contentDao(): ContentDao
     abstract fun contentLinkDao(): ContentLinkDao
+    abstract fun routeLocationIndexDao(): RouteLocationIndexDao
 }
 
 @Single
@@ -193,4 +201,9 @@ fun contentDao(db: AppDatabase): ContentDao {
 @Factory
 fun contentLinkDao(db: AppDatabase): ContentLinkDao {
     return db.contentLinkDao()
+}
+
+@Factory
+fun routeLocationIndexDao(db: AppDatabase): RouteLocationIndexDao {
+    return db.routeLocationIndexDao()
 }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/room/dao/RouteLocationIndexDao.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/room/dao/RouteLocationIndexDao.kt
@@ -3,6 +3,7 @@ package cl.emilym.sinatra.room.dao
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.Query
+import androidx.room.Transaction
 import cl.emilym.sinatra.room.entities.RouteLocationIndexEntity
 
 @Dao
@@ -23,7 +24,9 @@ interface RouteLocationIndexDao {
     @Query(
         "SELECT * FROM routeLocationIndexEntity WHERE " +
                 "lat BETWEEN :southLat AND :northLat AND " +
-                "lng BETWEEN :westLng AND :eastLng"
+                "(lng BETWEEN :westLng AND :eastLng OR " +
+                "(:westLng > :eastLng AND (lng BETWEEN :westLng AND 180 OR " +
+                "lng BETWEEN -180 AND :eastLng)))"
     )
     suspend fun getInBox(
         southLat: Double,
@@ -31,5 +34,11 @@ interface RouteLocationIndexDao {
         northLat: Double,
         eastLng: Double
     ): List<RouteLocationIndexEntity>
+
+    @Transaction
+    suspend fun clearAndInsert(vararg indicies: RouteLocationIndexEntity) {
+        clear()
+        insert(*indicies)
+    }
 
 }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/room/dao/RouteLocationIndexDao.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/room/dao/RouteLocationIndexDao.kt
@@ -1,0 +1,35 @@
+package cl.emilym.sinatra.room.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import cl.emilym.sinatra.room.entities.RouteLocationIndexEntity
+
+@Dao
+interface RouteLocationIndexDao {
+
+    @Insert
+    suspend fun insert(vararg indicies: RouteLocationIndexEntity)
+
+    @Query("DELETE FROM routeLocationIndexEntity")
+    suspend fun clear()
+
+    @Query("SELECT * FROM routeLocationIndexEntity")
+    suspend fun get(): List<RouteLocationIndexEntity>
+
+    @Query("SELECT * FROM routeLocationIndexEntity WHERE id = :id")
+    suspend fun get(id: String): RouteLocationIndexEntity?
+
+    @Query(
+        "SELECT * FROM routeLocationIndexEntity WHERE " +
+                "lat BETWEEN :southLat AND :northLat AND " +
+                "lng BETWEEN :westLng AND :eastLng"
+    )
+    suspend fun getInBox(
+        southLat: Double,
+        westLng: Double,
+        northLat: Double,
+        eastLng: Double
+    ): List<RouteLocationIndexEntity>
+
+}

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/room/entities/RouteLocationIndexEntity.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/room/entities/RouteLocationIndexEntity.kt
@@ -1,0 +1,40 @@
+package cl.emilym.sinatra.room.entities
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import cl.emilym.sinatra.data.models.MapLocation
+import cl.emilym.sinatra.data.models.RouteLocationIndex
+
+@Entity
+class RouteLocationIndexEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val lat: Double,
+    val lng: Double,
+    val routeIds: String
+) {
+
+    fun toModel(): RouteLocationIndex {
+        return RouteLocationIndex(
+            point = MapLocation(
+                lat = lat,
+                lng = lng
+            ),
+            routeIds = when (routeIds) {
+                "" -> emptyList()
+                else -> routeIds.split(",")
+            }
+        )
+    }
+
+    companion object {
+        fun fromModel(model: RouteLocationIndex): RouteLocationIndexEntity {
+            return RouteLocationIndexEntity(
+                id = 0,
+                lat = model.point.lat,
+                lng = model.point.lng,
+                routeIds = model.routeIds.joinToString(",")
+            )
+        }
+    }
+
+}

--- a/shared/src/commonMain/proto/gtfs-api.proto
+++ b/shared/src/commonMain/proto/gtfs-api.proto
@@ -83,6 +83,10 @@ message RealtimeEndpoint {
     optional string expireTimestamp = 2;
 }
 
+message RouteLocationIndexEndpoint {
+  repeated RouteLocationIndex indicies = 1;
+}
+
 message Stop {
   required string id = 1;
   optional string parentStation = 5;
@@ -264,4 +268,9 @@ message ServiceAlert {
 message RealtimeUpdate {
     required string tripId = 1;
     optional int32 delay = 2;
+}
+
+message RouteLocationIndex {
+  required Location point = 1;
+  repeated string routeId = 2;
 }

--- a/ui/src/androidMain/kotlin/cl/emilym/sinatra/ui/maps/AndroidMapControl.kt
+++ b/ui/src/androidMain/kotlin/cl/emilym/sinatra/ui/maps/AndroidMapControl.kt
@@ -1,6 +1,8 @@
 package cl.emilym.sinatra.ui.maps
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.unit.Density
 import cl.emilym.sinatra.data.models.MapLocation
@@ -39,6 +41,20 @@ class AndroidMapControl(
     }
 
     override val nativeZoom: Float get() = cameraPositionState.position.zoom
+
+    override val cameraRegion: MapRegion? by derivedStateOf {
+        val projection = cameraPositionState.projection ?: return@derivedStateOf null
+        MapRegion(
+            projection.fromScreenLocation(ScreenLocation(
+                contentViewportPadding.top,
+                contentViewportPadding.left,
+            ).toNative()).toShared(),
+            projection.fromScreenLocation(ScreenLocation(
+                contentViewportSize.height + contentViewportPadding.top,
+                contentViewportSize.width + contentViewportPadding.left
+            ).toNative()).toShared()
+        )
+    }
 
     override fun showBounds(bounds: MapRegion) {
         mainScope.launch {

--- a/ui/src/androidMain/kotlin/cl/emilym/sinatra/ui/maps/AndroidMapControl.kt
+++ b/ui/src/androidMain/kotlin/cl/emilym/sinatra/ui/maps/AndroidMapControl.kt
@@ -40,7 +40,9 @@ class AndroidMapControl(
         return projection.fromScreenLocation(coordinate.toNative()).toShared()
     }
 
-    override val nativeZoom: Float get() = cameraPositionState.position.zoom
+    override val nativeZoom: Float by derivedStateOf {
+        cameraPositionState.position.zoom
+    }
 
     override val cameraRegion: MapRegion? by derivedStateOf {
         val projection = cameraPositionState.projection ?: return@derivedStateOf null

--- a/ui/src/androidMain/kotlin/cl/emilym/sinatra/ui/maps/AndroidMapControl.kt
+++ b/ui/src/androidMain/kotlin/cl/emilym/sinatra/ui/maps/AndroidMapControl.kt
@@ -48,12 +48,12 @@ class AndroidMapControl(
         val projection = cameraPositionState.projection ?: return@derivedStateOf null
         MapRegion(
             projection.fromScreenLocation(ScreenLocation(
-                contentViewportPadding.top,
                 contentViewportPadding.left,
+                contentViewportPadding.top,
             ).toNative()).toShared(),
             projection.fromScreenLocation(ScreenLocation(
+                contentViewportSize.width + contentViewportPadding.left,
                 contentViewportSize.height + contentViewportPadding.top,
-                contentViewportSize.width + contentViewportPadding.left
             ).toNative()).toShared()
         )
     }

--- a/ui/src/commonMain/composeResources/values/strings.xml
+++ b/ui/src/commonMain/composeResources/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="browse_option_disclaimer">Sources and disclaimers</string>
     <string name="browse_option_upcoming_routes">Upcoming vehicles to %1$s</string>
 
-    <string name="browse_routes_in_area">"Routes in Area"</string>
+    <string name="browse_routes_in_area">Routes in Area</string>
 
     <string name="favourites_nothing_favourited">Any routes or stops you favourite can be found here</string>
     <string name="favourites_no_home">Add home</string>

--- a/ui/src/commonMain/composeResources/values/strings.xml
+++ b/ui/src/commonMain/composeResources/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="browse_option_upcoming_routes">Upcoming vehicles to %1$s</string>
 
     <string name="browse_routes_in_area">Routes in Area</string>
+    <string name="browse_routes_in_area_show_all">Show all</string>
     <string name="browse_routes_in_area_no_routes">There are no routes in this area.</string>
 
     <string name="favourites_nothing_favourited">Any routes or stops you favourite can be found here</string>

--- a/ui/src/commonMain/composeResources/values/strings.xml
+++ b/ui/src/commonMain/composeResources/values/strings.xml
@@ -9,6 +9,8 @@
     <string name="browse_option_disclaimer">Sources and disclaimers</string>
     <string name="browse_option_upcoming_routes">Upcoming vehicles to %1$s</string>
 
+    <string name="browse_routes_in_area">"Routes in Area"</string>
+
     <string name="favourites_nothing_favourited">Any routes or stops you favourite can be found here</string>
     <string name="favourites_no_home">Add home</string>
     <string name="favourites_no_work">Add work</string>

--- a/ui/src/commonMain/composeResources/values/strings.xml
+++ b/ui/src/commonMain/composeResources/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="browse_option_upcoming_routes">Upcoming vehicles to %1$s</string>
 
     <string name="browse_routes_in_area">Routes in Area</string>
+    <string name="browse_routes_in_area_no_routes">There are no routes in this area.</string>
 
     <string name="favourites_nothing_favourited">Any routes or stops you favourite can be found here</string>
     <string name="favourites_no_home">Add home</string>

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/maps/MapControl.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/maps/MapControl.kt
@@ -22,6 +22,9 @@ interface MapProjectionProvider {
 }
 
 interface MapControl {
+
+    val cameraRegion: MapRegion?
+
     fun zoomToArea(bounds: MapRegion, padding: Dp)
     fun zoomToArea(topLeft: MapLocation, bottomRight: MapLocation, padding: Dp)
     fun zoomToPoint(location: MapLocation, zoom: Zoom = 16f)
@@ -32,6 +35,8 @@ interface MapControl {
 
 class SafeMapControl: MapControl {
     var wrapped: MapControl? = null
+
+    override val cameraRegion: MapRegion? = wrapped?.cameraRegion
 
     override fun zoomToArea(bounds: MapRegion, padding: Dp) {
         wrapped?.zoomToArea(bounds, padding)

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/maps/MapControl.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/maps/MapControl.kt
@@ -1,6 +1,10 @@
 package cl.emilym.sinatra.ui.maps
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -34,9 +38,11 @@ interface MapControl {
 }
 
 class SafeMapControl: MapControl {
-    var wrapped: MapControl? = null
+    var wrapped: MapControl? by mutableStateOf(null)
 
-    override val cameraRegion: MapRegion? = wrapped?.cameraRegion
+    override val cameraRegion: MapRegion? by derivedStateOf {
+        wrapped?.cameraRegion
+    }
 
     override fun zoomToArea(bounds: MapRegion, padding: Dp) {
         wrapped?.zoomToArea(bounds, padding)

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/maps/MapControl.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/maps/MapControl.kt
@@ -60,8 +60,9 @@ class SafeMapControl: MapControl {
         wrapped?.moveToPoint(location, minZoom)
     }
 
-    override val zoom: Float
-        get() = wrapped?.zoom ?: 0f
+    override val zoom: Float by derivedStateOf {
+        wrapped?.zoom ?: 0f
+    }
 }
 
 abstract class AbstractMapControl: MapControl, MapProjectionProvider {
@@ -109,8 +110,9 @@ abstract class AbstractMapControl: MapControl, MapProjectionProvider {
     abstract fun showBounds(bounds: MapRegion)
 
     abstract val nativeZoom: Float
-    override val zoom: Float
-        get() = calculateZoom(nativeZoom, visibleMapSize, density)
+    override val zoom: Float by derivedStateOf {
+        calculateZoom(nativeZoom, visibleMapSize, density)
+    }
 
 
     override fun zoomToArea(

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/MapSearchScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/MapSearchScreen.kt
@@ -147,7 +147,7 @@ class MapSearchScreen: MapScreen, NativeMapScreen {
         }
 
         LaunchedEffect(mapControl.cameraRegion) {
-            mapControl.cameraRegion?.let { browseViewModel.updateCameraRegion(it) }
+            mapControl.cameraRegion?.let { browseViewModel.updateCameraRegion(it, mapControl.zoom) }
         }
 
         LaunchedEffect(state) {

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/MapSearchScreen.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/MapSearchScreen.kt
@@ -133,6 +133,7 @@ class MapSearchScreen: MapScreen, NativeMapScreen {
         val browseViewModel = koinScreenModel<BrowseViewModel>()
         val state by viewModel.state.collectAsStateWithLifecycle()
         val navigator = LocalNavigator.currentOrThrow
+        val mapControl = LocalMapControl.current
 
         val bottomSheetState = LocalBottomSheetState.current
         val keyboardController = LocalSoftwareKeyboardController.current
@@ -143,6 +144,10 @@ class MapSearchScreen: MapScreen, NativeMapScreen {
             )) {
                 keyboardController?.hide()
             }
+        }
+
+        LaunchedEffect(mapControl.cameraRegion) {
+            mapControl.cameraRegion?.let { browseViewModel.updateCameraRegion(it) }
         }
 
         LaunchedEffect(state) {

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/BrowseViewModel.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/BrowseViewModel.kt
@@ -89,10 +89,7 @@ class BrowseViewModel(
     private val _mapArea = MutableStateFlow<MapRegion?>(null)
 
     private val _routes = _mapArea
-        .distinctUntilChanged { old, new ->
-            if (old == null || new == null) return@distinctUntilChanged true
-            regionDistinctUseCase(old, new)
-        }.flatRequestStateFlow(defaultConfig) {
+        .flatRequestStateFlow(defaultConfig) {
             routesInAreaUseCase(it)
         }
     val routes = _routes.state(RequestState.Initial())
@@ -197,6 +194,7 @@ class BrowseViewModel(
     }
 
     fun updateCameraRegion(region: MapRegion) {
+        Napier.d("MapRegion updated $region")
         _mapArea.value = region
     }
 

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/BrowseViewModel.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/BrowseViewModel.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.mapLatest
@@ -44,6 +45,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Factory
 import kotlin.math.abs
+import kotlin.time.Duration.Companion.seconds
 
 sealed interface QuickNavigationItem {
     val special: SpecialFavouriteType?
@@ -86,7 +88,6 @@ sealed interface BrowsePrompt {
 class BrowseViewModel(
     private val displayRoutesUseCase: DisplayRoutesUseCase,
     private val routesInAreaUseCase: RoutesInAreaUseCase,
-    private val regionDistinctUseCase: RegionDistinctUseCase,
     private val newServiceUpdateUseCase: NewServiceUpdateUseCase,
     private val quickNavigateUseCase: QuickNavigateUseCase,
     private val specialAddUseCase: SpecialAddUseCase,
@@ -98,10 +99,8 @@ class BrowseViewModel(
     private val _mapArea = MutableStateFlow<MapRegionAndZoom?>(null)
 
     private val _routes = _mapArea
-        .distinctUntilChanged { old, new ->
-            if (old == null || new == null) return@distinctUntilChanged true
-            regionDistinctUseCase(old.mapRegion, new.mapRegion)
-        }.flatRequestStateFlow(defaultConfig) {
+        .debounce(0.1.seconds)
+        .flatRequestStateFlow(defaultConfig) {
             if (it == null || it.zoom < zoomThreshold) {
                 displayRoutesUseCase().mapLatest {
                     RoutesInArea(

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/BrowseViewModel.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/BrowseViewModel.kt
@@ -6,6 +6,7 @@ import cl.emilym.compose.requeststate.flatRequestStateFlow
 import cl.emilym.compose.requeststate.requestStateFlow
 import cl.emilym.compose.requeststate.unwrap
 import cl.emilym.sinatra.data.models.MapLocation
+import cl.emilym.sinatra.data.models.MapRegion
 import cl.emilym.sinatra.data.models.ServiceAlert
 import cl.emilym.sinatra.data.models.ServiceAlertId
 import cl.emilym.sinatra.data.models.SpecialFavouriteType
@@ -13,6 +14,8 @@ import cl.emilym.sinatra.data.models.distance
 import cl.emilym.sinatra.data.repository.RemoteConfigRepository
 import cl.emilym.sinatra.data.repository.ServiceAlertRepository
 import cl.emilym.sinatra.domain.DisplayRoutesUseCase
+import cl.emilym.sinatra.domain.RegionDistinctUseCase
+import cl.emilym.sinatra.domain.RoutesInAreaUseCase
 import cl.emilym.sinatra.domain.prompt.FavouriteNearbyStopDeparturesUseCase
 import cl.emilym.sinatra.domain.prompt.NewServiceUpdateUseCase
 import cl.emilym.sinatra.domain.prompt.QuickNavigateUseCase
@@ -31,11 +34,13 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Factory
+import kotlin.math.abs
 
 sealed interface QuickNavigationItem {
     val special: SpecialFavouriteType?
@@ -71,7 +76,8 @@ sealed interface BrowsePrompt {
 
 @Factory
 class BrowseViewModel(
-    private val displayRoutesUseCase: DisplayRoutesUseCase,
+    private val routesInAreaUseCase: RoutesInAreaUseCase,
+    private val regionDistinctUseCase: RegionDistinctUseCase,
     private val newServiceUpdateUseCase: NewServiceUpdateUseCase,
     private val quickNavigateUseCase: QuickNavigateUseCase,
     private val specialAddUseCase: SpecialAddUseCase,
@@ -80,7 +86,15 @@ class BrowseViewModel(
     private val remoteConfigRepository: RemoteConfigRepository
 ): SinatraScreenModel {
 
-    private val _routes = flatRequestStateFlow(defaultConfig) { displayRoutesUseCase().mapLatest { it.item } }
+    private val _mapArea = MutableStateFlow<MapRegion?>(null)
+
+    private val _routes = _mapArea
+        .distinctUntilChanged { old, new ->
+            if (old == null || new == null) return@distinctUntilChanged true
+            regionDistinctUseCase(old, new)
+        }.flatRequestStateFlow(defaultConfig) {
+            routesInAreaUseCase(it)
+        }
     val routes = _routes.state(RequestState.Initial())
 
     private val lastLocation = MutableStateFlow<MapLocation?>(null)
@@ -180,6 +194,10 @@ class BrowseViewModel(
 
         if (distance(ll, location) < 0.5) return
         lastLocation.value = location
+    }
+
+    fun updateCameraRegion(region: MapRegion) {
+        _mapArea.value = region
     }
 
     fun markAlertViewed(id: ServiceAlertId) {

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/BrowseViewModel.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/BrowseViewModel.kt
@@ -36,11 +36,13 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.core.annotation.Factory
@@ -97,10 +99,24 @@ class BrowseViewModel(
 ): SinatraScreenModel {
 
     private val _mapArea = MutableStateFlow<MapRegionAndZoom?>(null)
+    private val _forceShowAllRoutes = MutableStateFlow(false)
+    val forceShowAllRoutes = _forceShowAllRoutes.asStateFlow()
 
     private val _routes = _mapArea
         .debounce(0.1.seconds)
-        .flatRequestStateFlow(defaultConfig) {
+        .onEach {
+            _forceShowAllRoutes.value = false
+        }.combine(
+            forceShowAllRoutes,
+        ) { _mapArea, forceShowAllRoutes ->
+            if (forceShowAllRoutes) {
+                _mapArea?.copy(
+                    zoom = 0f
+                )
+            } else {
+                _mapArea
+            }
+        }.flatRequestStateFlow(defaultConfig) {
             if (it == null || it.zoom < zoomThreshold) {
                 displayRoutesUseCase().mapLatest {
                     RoutesInArea(
@@ -218,6 +234,10 @@ class BrowseViewModel(
             region,
             zoom
         )
+    }
+
+    fun forceShowAllRoutes() {
+        _forceShowAllRoutes.value = true
     }
 
     fun markAlertViewed(id: ServiceAlertId) {

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/BrowseViewModel.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/BrowseViewModel.kt
@@ -10,11 +10,13 @@ import cl.emilym.sinatra.data.models.MapRegion
 import cl.emilym.sinatra.data.models.ServiceAlert
 import cl.emilym.sinatra.data.models.ServiceAlertId
 import cl.emilym.sinatra.data.models.SpecialFavouriteType
+import cl.emilym.sinatra.data.models.Zoom
 import cl.emilym.sinatra.data.models.distance
 import cl.emilym.sinatra.data.repository.RemoteConfigRepository
 import cl.emilym.sinatra.data.repository.ServiceAlertRepository
 import cl.emilym.sinatra.domain.DisplayRoutesUseCase
 import cl.emilym.sinatra.domain.RegionDistinctUseCase
+import cl.emilym.sinatra.domain.RoutesInArea
 import cl.emilym.sinatra.domain.RoutesInAreaUseCase
 import cl.emilym.sinatra.domain.prompt.FavouriteNearbyStopDeparturesUseCase
 import cl.emilym.sinatra.domain.prompt.NewServiceUpdateUseCase
@@ -23,6 +25,7 @@ import cl.emilym.sinatra.domain.prompt.SpecialAddUseCase
 import cl.emilym.sinatra.domain.prompt.StopDepartures
 import cl.emilym.sinatra.nullIfEmpty
 import cl.emilym.sinatra.ui.presentation.screens.maps.navigate.NavigationLocation
+import cl.emilym.sinatra.ui.presentation.screens.maps.search.zoomThreshold
 import cl.emilym.sinatra.ui.retryIfNeeded
 import cl.emilym.sinatra.ui.toNavigationLocation
 import cl.emilym.sinatra.ui.widgets.SinatraScreenModel
@@ -61,6 +64,11 @@ sealed interface QuickNavigationItem {
     }
 }
 
+private data class MapRegionAndZoom(
+    val mapRegion: MapRegion,
+    val zoom: Zoom
+)
+
 sealed interface BrowsePrompt {
     data class QuickNavigateGroup(
         val items: List<QuickNavigationItem>
@@ -76,6 +84,7 @@ sealed interface BrowsePrompt {
 
 @Factory
 class BrowseViewModel(
+    private val displayRoutesUseCase: DisplayRoutesUseCase,
     private val routesInAreaUseCase: RoutesInAreaUseCase,
     private val regionDistinctUseCase: RegionDistinctUseCase,
     private val newServiceUpdateUseCase: NewServiceUpdateUseCase,
@@ -86,11 +95,23 @@ class BrowseViewModel(
     private val remoteConfigRepository: RemoteConfigRepository
 ): SinatraScreenModel {
 
-    private val _mapArea = MutableStateFlow<MapRegion?>(null)
+    private val _mapArea = MutableStateFlow<MapRegionAndZoom?>(null)
 
     private val _routes = _mapArea
-        .flatRequestStateFlow(defaultConfig) {
-            routesInAreaUseCase(it)
+        .distinctUntilChanged { old, new ->
+            if (old == null || new == null) return@distinctUntilChanged true
+            regionDistinctUseCase(old.mapRegion, new.mapRegion)
+        }.flatRequestStateFlow(defaultConfig) {
+            if (it == null || it.zoom < zoomThreshold) {
+                displayRoutesUseCase().mapLatest {
+                    RoutesInArea(
+                        it.item,
+                        false
+                    )
+                }
+            } else {
+                routesInAreaUseCase(it.mapRegion)
+            }
         }
     val routes = _routes.state(RequestState.Initial())
 
@@ -193,9 +214,11 @@ class BrowseViewModel(
         lastLocation.value = location
     }
 
-    fun updateCameraRegion(region: MapRegion) {
-        Napier.d("MapRegion updated $region")
-        _mapArea.value = region
+    fun updateCameraRegion(region: MapRegion, zoom: Zoom) {
+        _mapArea.value = MapRegionAndZoom(
+            region,
+            zoom
+        )
     }
 
     fun markAlertViewed(id: ServiceAlertId) {

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/MapSearchScreenBrowseState.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/MapSearchScreenBrowseState.kt
@@ -1,12 +1,16 @@
 package cl.emilym.sinatra.ui.presentation.screens.maps.search.browse
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -36,6 +40,7 @@ import org.jetbrains.compose.resources.stringResource
 import sinatra.ui.generated.resources.Res
 import sinatra.ui.generated.resources.browse_routes_in_area
 import sinatra.ui.generated.resources.browse_routes_in_area_no_routes
+import sinatra.ui.generated.resources.browse_routes_in_area_show_all
 
 @OptIn(ExperimentalVoyagerApi::class)
 @Composable
@@ -111,11 +116,26 @@ fun Screen.MapSearchScreenBrowseState(
                     }
                     if (routes.isRelevantToRegion) {
                         item {
-                            Text(
-                                stringResource(Res.string.browse_routes_in_area),
-                                style = MaterialTheme.typography.titleMedium,
-                                modifier = Modifier.padding(horizontal = 1.rdp)
-                            )
+                            val forceShowAllRoutes by viewModel.forceShowAllRoutes.collectAsStateWithLifecycle()
+                            Row(
+                                Modifier.fillMaxWidth()
+                                    .padding(horizontal = 1.rdp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(1.rdp)
+                            ) {
+                                Text(
+                                    stringResource(Res.string.browse_routes_in_area),
+                                    style = MaterialTheme.typography.titleMedium,
+                                    modifier = Modifier.weight(1f)
+                                )
+                                if (!forceShowAllRoutes) {
+                                    FilledTonalButton(
+                                        onClick = viewModel::forceShowAllRoutes
+                                    ) {
+                                        Text(stringResource(Res.string.browse_routes_in_area_show_all))
+                                    }
+                                }
+                            }
                             Spacer(Modifier.height(0.25.rdp))
                             if (routes.routes.isEmpty()) {
                                 ListHint(

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/MapSearchScreenBrowseState.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/MapSearchScreenBrowseState.kt
@@ -147,7 +147,7 @@ fun Screen.MapSearchScreenBrowseState(
                             }
                         }
                     }
-                    items(routes.routes.size) {
+                    items(routes.routes.size, key = { "route-${routes.routes[it].id}" }) {
                         RouteCard(
                             routes.routes[it],
                             onClick = {
@@ -156,7 +156,8 @@ fun Screen.MapSearchScreenBrowseState(
                                         routes.routes[it].id
                                     )
                                 )
-                            }
+                            },
+                            modifier = Modifier.animateItem()
                         )
                     }
                     item {

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/MapSearchScreenBrowseState.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/MapSearchScreenBrowseState.kt
@@ -4,9 +4,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -26,6 +29,9 @@ import cl.emilym.sinatra.ui.widgets.AlertScaffold
 import cl.emilym.sinatra.ui.widgets.RouteCard
 import cl.emilym.sinatra.ui.widgets.collectAsStateWithLifecycle
 import cl.emilym.sinatra.ui.widgets.currentLocation
+import org.jetbrains.compose.resources.stringResource
+import sinatra.ui.generated.resources.Res
+import sinatra.ui.generated.resources.browse_routes_in_area
 
 @OptIn(ExperimentalVoyagerApi::class)
 @Composable
@@ -98,6 +104,16 @@ fun Screen.MapSearchScreenBrowseState(
                             else -> {}
                         }
                         Spacer(Modifier.height(1.rdp))
+                    }
+                    if (routes.isRelevantToRegion) {
+                        item {
+                            Text(
+                                stringResource(Res.string.browse_routes_in_area),
+                                style = MaterialTheme.typography.titleMedium,
+                                modifier = Modifier.padding(horizontal = 1.rdp)
+                            )
+                            Spacer(Modifier.height(0.25.rdp))
+                        }
                     }
                     items(routes.routes.size) {
                         RouteCard(

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/MapSearchScreenBrowseState.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/MapSearchScreenBrowseState.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -26,12 +27,15 @@ import cl.emilym.sinatra.ui.navigation.LocalBottomSheetState
 import cl.emilym.sinatra.ui.presentation.screens.maps.route.RouteDetailScreen
 import cl.emilym.sinatra.ui.presentation.screens.maps.search.MapSearchViewModel
 import cl.emilym.sinatra.ui.widgets.AlertScaffold
+import cl.emilym.sinatra.ui.widgets.ListHint
+import cl.emilym.sinatra.ui.widgets.NoBusIcon
 import cl.emilym.sinatra.ui.widgets.RouteCard
 import cl.emilym.sinatra.ui.widgets.collectAsStateWithLifecycle
 import cl.emilym.sinatra.ui.widgets.currentLocation
 import org.jetbrains.compose.resources.stringResource
 import sinatra.ui.generated.resources.Res
 import sinatra.ui.generated.resources.browse_routes_in_area
+import sinatra.ui.generated.resources.browse_routes_in_area_no_routes
 
 @OptIn(ExperimentalVoyagerApi::class)
 @Composable
@@ -113,6 +117,14 @@ fun Screen.MapSearchScreenBrowseState(
                                 modifier = Modifier.padding(horizontal = 1.rdp)
                             )
                             Spacer(Modifier.height(0.25.rdp))
+                            if (routes.routes.isEmpty()) {
+                                ListHint(
+                                    stringResource(Res.string.browse_routes_in_area_no_routes),
+                                    modifier = Modifier.padding(horizontal = 1.rdp)
+                                ) {
+                                    NoBusIcon()
+                                }
+                            }
                         }
                     }
                     items(routes.routes.size) {

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/MapSearchScreenBrowseState.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/MapSearchScreenBrowseState.kt
@@ -99,13 +99,13 @@ fun Screen.MapSearchScreenBrowseState(
                         }
                         Spacer(Modifier.height(1.rdp))
                     }
-                    items(routes.size) {
+                    items(routes.routes.size) {
                         RouteCard(
-                            routes[it],
+                            routes.routes[it],
                             onClick = {
                                 navigator.push(
                                     RouteDetailScreen(
-                                        routes[it].id
+                                        routes.routes[it].id
                                     )
                                 )
                             }

--- a/ui/src/iosMain/kotlin/cl/emilym/sinatra/ui/maps/AppleMapControl.kt
+++ b/ui/src/iosMain/kotlin/cl/emilym/sinatra/ui/maps/AppleMapControl.kt
@@ -1,6 +1,8 @@
 package cl.emilym.sinatra.ui.maps
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.unit.Density
 import cl.emilym.sinatra.data.models.MapLocation
@@ -26,8 +28,13 @@ class AppleMapControl(
     override val density: Density
 ): AbstractMapControl() {
 
-    override val zoom: Float
-        get() = calculateZoom(nativeZoom, visibleMapSize, density) + ZOOM_OFFSET
+    override val cameraRegion: MapRegion? by derivedStateOf {
+        state.cameraDescription.mapRegion
+    }
+
+    override val zoom: Float by derivedStateOf {
+        calculateZoom(nativeZoom, visibleMapSize, density) + ZOOM_OFFSET
+    }
 
     @OptIn(ExperimentalForeignApi::class)
     override fun toScreenSpace(location: MapLocation): ScreenLocation? {
@@ -41,7 +48,9 @@ class AppleMapControl(
         return map.convertPoint(coordinate.toNative(), toCoordinateFromView = map).toShared()
     }
 
-    override val nativeZoom: Float get() = state.cameraDescription.zoom(contentViewportSize.dp(density.density))
+    override val nativeZoom: Float by derivedStateOf {
+        state.cameraDescription.zoom(contentViewportSize.dp(density.density))
+    }
 
     override fun showBounds(bounds: MapRegion) {
         state.animate(CameraDescription(


### PR DESCRIPTION
## Summary by Sourcery

Show only routes relevant to the current map viewport while preserving access to the complete route list.

New Features:
- Filter browse results to routes associated with stops or route geometry within the visible map region, with an option to show all routes.
- Add a cached route-location index fetched from the GTFS API and queried by geographic bounding box.
- Expose the current map camera region on Android and iOS map controls to drive viewport-aware browsing.

Enhancements:
- Avoid refreshing area-based route results for insignificant map movements or resizes and fall back to the complete route list when area filtering is unavailable or zoomed out.

Chores:
- Add Room persistence and migration support for the route-location index.