### PR TITLE
Better catch exceptions in RoutesInArea call

### DIFF
--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/RoutesInAreaUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/RoutesInAreaUseCase.kt
@@ -3,6 +3,8 @@ package cl.emilym.sinatra.domain
 import cl.emilym.sinatra.data.models.MapRegion
 import cl.emilym.sinatra.data.models.Route
 import cl.emilym.sinatra.data.repository.RouteRepository
+import cl.emilym.sinatra.e
+import io.github.aakira.napier.Napier
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -24,21 +26,25 @@ class RoutesInAreaUseCase(
 ) {
 
     operator fun invoke(area: MapRegion): Flow<RoutesInArea> = flow {
-        emitAll(
-            getFilteredRoutesUseCase.filterRoutes(routeRepository.routesInBox(area)).map {
-                RoutesInArea(
-                    it,
-                    true
-                )
-            }.catch {
-                emitAll(getFilteredRoutesUseCase().map {
+        try {
+            val routes = routeRepository.routesInBox(area)
+            emitAll(
+                getFilteredRoutesUseCase.filterRoutes(routes).map {
                     RoutesInArea(
-                        it.item,
-                        false
+                        it,
+                        true
                     )
-                })
-            }
-        )
+                }
+            )
+        } catch (e: Exception) {
+            Napier.e(e)
+            emitAll(getFilteredRoutesUseCase().map {
+                RoutesInArea(
+                    it.item,
+                    false
+                )
+            })
+        }
     }
 
 }

--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/RoutesInAreaUseCase.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/domain/RoutesInAreaUseCase.kt
@@ -26,16 +26,8 @@ class RoutesInAreaUseCase(
 ) {
 
     operator fun invoke(area: MapRegion): Flow<RoutesInArea> = flow {
-        try {
-            val routes = routeRepository.routesInBox(area)
-            emitAll(
-                getFilteredRoutesUseCase.filterRoutes(routes).map {
-                    RoutesInArea(
-                        it,
-                        true
-                    )
-                }
-            )
+        val routes = try {
+            routeRepository.routesInBox(area)
         } catch (e: Exception) {
             Napier.e(e)
             emitAll(getFilteredRoutesUseCase().map {
@@ -44,7 +36,16 @@ class RoutesInAreaUseCase(
                     false
                 )
             })
+            return@flow
         }
+        emitAll(
+            getFilteredRoutesUseCase.filterRoutes(routes).map {
+                RoutesInArea(
+                    it,
+                    true
+                )
+            }
+        )
     }
 
 }


### PR DESCRIPTION
## Summary by Sourcery

Improve RoutesInArea error handling to preserve usable route results when area retrieval fails.

Bug Fixes:
- Handle route retrieval failures by logging the exception and falling back to locally filtered routes.

Enhancements:
- Simplify route-area flow error handling by applying the fallback when the repository request fails.