### PR TITLE
Don't show routes in area if outside canberra region

### DIFF
--- a/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Location.kt
+++ b/shared/src/commonMain/kotlin/cl/emilym/sinatra/data/models/Location.kt
@@ -92,6 +92,15 @@ data class MapRegion(
         bottomRight.lat, topLeft.lng
     )
 
+    fun intersects(other: MapRegion): Boolean {
+        return !(
+            bottomRight.lng < other.topLeft.lng ||
+            topLeft.lng > other.bottomRight.lng ||
+            bottomRight.lat < other.topLeft.lat ||
+            topLeft.lat > other.bottomRight.lat
+        )
+    }
+
 }
 
 const val EARTH_RADIUS = 6371.0

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/BrowseViewModel.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/BrowseViewModel.kt
@@ -121,11 +121,7 @@ class BrowseViewModel(
             if (
                 it == null ||
                 it.zoom < zoomThreshold ||
-                (
-                    !canberraRegion.contains(it.mapRegion.northEast) &&
-                    !canberraRegion.contains(it.mapRegion.southWest) &&
-                    !canberraRegion.contains(it.mapRegion.center)
-                )
+                canberraRegion.intersects(it.mapRegion)
             ) {
                 displayRoutesUseCase().mapLatest {
                     RoutesInArea(

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/BrowseViewModel.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/BrowseViewModel.kt
@@ -121,7 +121,11 @@ class BrowseViewModel(
             if (
                 it == null ||
                 it.zoom < zoomThreshold ||
-                (!canberraRegion.contains(it.mapRegion.northEast) && !canberraRegion.contains(it.mapRegion.southWest))
+                (
+                    !canberraRegion.contains(it.mapRegion.northEast) &&
+                    !canberraRegion.contains(it.mapRegion.southWest) &&
+                    !canberraRegion.contains(it.mapRegion.center)
+                )
             ) {
                 displayRoutesUseCase().mapLatest {
                     RoutesInArea(

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/BrowseViewModel.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/BrowseViewModel.kt
@@ -121,7 +121,7 @@ class BrowseViewModel(
             if (
                 it == null ||
                 it.zoom < zoomThreshold ||
-                canberraRegion.intersects(it.mapRegion)
+                !canberraRegion.intersects(it.mapRegion)
             ) {
                 displayRoutesUseCase().mapLatest {
                     RoutesInArea(

--- a/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/BrowseViewModel.kt
+++ b/ui/src/commonMain/kotlin/cl/emilym/sinatra/ui/presentation/screens/maps/search/browse/BrowseViewModel.kt
@@ -24,6 +24,7 @@ import cl.emilym.sinatra.domain.prompt.QuickNavigateUseCase
 import cl.emilym.sinatra.domain.prompt.SpecialAddUseCase
 import cl.emilym.sinatra.domain.prompt.StopDepartures
 import cl.emilym.sinatra.nullIfEmpty
+import cl.emilym.sinatra.ui.canberraRegion
 import cl.emilym.sinatra.ui.presentation.screens.maps.navigate.NavigationLocation
 import cl.emilym.sinatra.ui.presentation.screens.maps.search.zoomThreshold
 import cl.emilym.sinatra.ui.retryIfNeeded
@@ -117,7 +118,11 @@ class BrowseViewModel(
                 _mapArea
             }
         }.flatRequestStateFlow(defaultConfig) {
-            if (it == null || it.zoom < zoomThreshold) {
+            if (
+                it == null ||
+                it.zoom < zoomThreshold ||
+                (!canberraRegion.contains(it.mapRegion.northEast) && !canberraRegion.contains(it.mapRegion.southWest))
+            ) {
                 displayRoutesUseCase().mapLatest {
                     RoutesInArea(
                         it.item,


### PR DESCRIPTION
## Summary by Sourcery

Restrict route browsing to map areas that intersect the Canberra region.

Bug Fixes:
- Prevent route results from being displayed when the viewed map area does not overlap the Canberra region.

Enhancements:
- Add map-region intersection detection for geographic bounds.